### PR TITLE
fix: reverses data display for the stacked bar chart tables

### DIFF
--- a/src/drizzle/patterns/data-types/table-with-category-column.hbs
+++ b/src/drizzle/patterns/data-types/table-with-category-column.hbs
@@ -8,9 +8,9 @@
   {{#each chartData }}
     <tr>
       <td class="table__category">{{ this.category }}</td>
-      <td><span class="table__value table__value--na">{{ this.na }}</span><span>%</span></td>
-      <td><span class="table__value table__value--1-3">{{ this.1-3 }}</span><span>%</span></td>
       <td><span class="table__value table__value--4-5">{{ this.4-5 }}</span><span>%</span></td>
+      <td><span class="table__value table__value--1-3">{{ this.1-3 }}</span><span>%</span></td>
+      <td><span class="table__value table__value--na">{{ this.na }}</span><span>%</span></td>
     </tr>
   {{/each}}
 </table>


### PR DESCRIPTION
- Data was appearing under incorrect headers

To Check:
- Ensure that data in the stacked bar charts is appearing in its correct order
- Turn off JS and ensure that the data in the stacked bar chart tables is appearing in its correct order.