### PR TITLE
feat: font styles

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -29,6 +29,7 @@ module.exports = {
       },
     },
     `gatsby-plugin-sass`,
+    `gatsby-plugin-react-helmet`,
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.dev/offline
     // `gatsby-plugin-offline`,

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -8,6 +8,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 import { StaticQuery, graphql } from "gatsby"
+import { Helmet } from "react-helmet";
 
 import Header from "./header"
 import "../scss/base.scss"
@@ -25,6 +26,10 @@ const Layout = ({ children }) => (
     `}
     render={data => (
       <>
+        <Helmet>
+          <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/655912/7241412/css/fonts.css" />
+          <link href="https://fonts.googleapis.com/css?family=Yellowtail&display=swap" rel="stylesheet" />
+        </Helmet>
         <Header siteTitle={data.site.siteMetadata.title} />
         <div
           style={{

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -35,8 +35,6 @@ const Layout = ({ children }) => (
           style={{
             margin: `0 auto`,
             maxWidth: 1400,
-            padding: `0px 1.0875rem 1.45rem`,
-            paddingTop: 0,
           }}
         >
           <main>{children}</main>

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -34,7 +34,7 @@ const Layout = ({ children }) => (
         <div
           style={{
             margin: `0 auto`,
-            maxWidth: 960,
+            maxWidth: 1400,
             padding: `0px 1.0875rem 1.45rem`,
             paddingTop: 0,
           }}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -8,9 +8,12 @@ import SEO from "../components/seo"
 const IndexPage = () => (
   <Layout>
     <SEO title="Home" />
-    <h1>Hi people</h1>
-    <p>Welcome to your new Gatsby site.</p>
-    <p>Now go build something great.</p>
+    <h1 class="headline-1"><span data-text="design systems">Design systems</span></h1>
+    <p class="accent-font"><span data-text="survey">Survey</span></p>
+    <h2 class="headline-1--small"><span data-text="Table of Contents">Table of Contents</span></h2>
+    <p class="headline-4" style={{background: `black`,}}>The Respondents</p>
+    <h3 class="headline-2">The Respondents</h3>
+    <p class="body-copy" style={{background: `black`,}}>This survey had 256 responses comprised of two respondent types:</p>
     <div style={{ maxWidth: `300px`, marginBottom: `1.45rem` }}>
       <Image />
     </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -13,6 +13,7 @@ const IndexPage = () => (
     <h2 class="headline-1--small"><span data-text="Table of Contents">Table of Contents</span></h2>
     <p class="headline-4" style={{background: `black`,}}>The Respondents</p>
     <h3 class="headline-2">The Respondents</h3>
+    <h4 class="headline-3"><span data-text="The 2019 Design Systems Survey received 148 responses from in-house teams who use a design system for their organizations.">The 2019 Design Systems Survey received 148 responses from in-house teams who use a design system for their organizations.</span></h4>
     <p class="body-copy" style={{background: `black`,}}>This survey had 256 responses comprised of two respondent types:</p>
     <div style={{ maxWidth: `300px`, marginBottom: `1.45rem` }}>
       <Image />

--- a/src/scss/_tools.typography.scss
+++ b/src/scss/_tools.typography.scss
@@ -17,7 +17,7 @@
       text-transform: uppercase;
       display: inline-block;
       -webkit-text-stroke: 1px #EEABEF;
-      filter: drop-shadow(0 0.0625em 0 #8D0429);
+      filter: drop-shadow(0 0.0325em 0 #8D0429);
 
       &::before {
         position: absolute;
@@ -25,7 +25,7 @@
         color: rgba(0,0,0,0);
         display: block;
         top: 0;
-        background: linear-gradient(0deg, #F448AF 21%, #4A062F 42%, #11161C 43%, #D2F0FD 45%, #146C8C 63%, #082534 77%);
+        background: linear-gradient(0deg, #F448AF 21%, #4A062F 42%, #11161C 47%, #D2F0FD 48%, #146C8C 63%, #082534 77%);
         background-clip: text;
         z-index: 2;
       }

--- a/src/scss/_tools.typography.scss
+++ b/src/scss/_tools.typography.scss
@@ -76,7 +76,39 @@
 }
 
 // For callout quotes
-@mixin headline-3 {}
+@mixin headline-3 {
+  font-family: "Gotham SSm A", "Gotham SSm B", sans-serif;
+  font-style: normal;
+  font-weight: 800;
+  font-size: 2.75rem;
+  line-height: 3rem;
+  text-shadow: 0 0 6px 0 rgba(243,196,72,0.2);
+
+  [data-text] {
+    font-family: inherit;
+    color: #DF138C;
+
+    @supports (background-clip: text) {
+      position: relative;
+      display: inline-block;
+
+      &::before {
+        position: absolute;
+        content: attr(data-text);
+        color: rgba(0,0,0,0);
+        display: block;
+        top: 0;
+        background-image: linear-gradient(180deg, #DF138C 0%, #F3C448 100%);
+        background-clip: text;
+        z-index: 2;
+      }
+    }
+  }
+}
+
+.headline-3 {
+  @include headline-3;
+}
 
 // Table of contents items
 @mixin headline-4 {

--- a/src/scss/_tools.typography.scss
+++ b/src/scss/_tools.typography.scss
@@ -1,10 +1,11 @@
+// Two tone gradient headers, hero section, TOC
 @mixin headline-1 {
   font-family: "Gotham SSm A", "Gotham SSm B", sans-serif;
   font-style: normal;
   font-weight: 800;
   text-align: center;
   margin: 0;
-  font-size: 10vw;
+  font-size: 8.75rem;
 
   [data-text] {
     font-family: inherit;
@@ -37,7 +38,7 @@
 
 .headline-1--small {
   @include headline-1;
-  font-size: 8vw;
+  font-size: 6.25rem;
 }
 
 // For "Survey," numbered list numbers, etc.
@@ -60,11 +61,13 @@
   @include accent-font;
 }
 
+// Section headers
 @mixin headline-2 {
   font-family: "Whitney SSm A", "Whitney SSm B", sans-serif;
   color: $white;
   font-size: 5rem;
   line-height: 4.5rem;
+  text-transform: uppercase;
   text-shadow: 0 2px 64px #11161C, 0 2px 4px #11161C, 0 2px 30px #11161C;
 }
 
@@ -72,10 +75,10 @@
   @include headline-2;
 }
 
-// For callouts
+// For callout quotes
 @mixin headline-3 {}
 
-// Table of contents
+// Table of contents items
 @mixin headline-4 {
   font-family: "Gotham SSm A", "Gotham SSm B", sans-serif;
   font-style: normal;
@@ -88,6 +91,7 @@
   @include headline-4;
 }
 
+// Intro text
 @mixin headline-5 {
   font-family: "Whitney SSm A", "Whitney SSm B", sans-serif;
   color: $white;
@@ -100,8 +104,8 @@
   @include headline-5;
 }
 
-@mixin body-copy($color: inherit) {
-  color: $color;
+@mixin body-copy {
+  color: $white;
   font-family: "Whitney SSm A", "Whitney SSm B", sans-serif;
   font-size: 1.5rem;
   font-weight: 300;

--- a/src/scss/_tools.typography.scss
+++ b/src/scss/_tools.typography.scss
@@ -5,7 +5,8 @@
   font-weight: 800;
   text-align: center;
   margin: 0;
-  font-size: 8.75rem;
+  font-size: 9vw;
+  white-space: nowrap;
 
   [data-text] {
     font-family: inherit;
@@ -38,7 +39,7 @@
 
 .headline-1--small {
   @include headline-1;
-  font-size: 6.25rem;
+  font-size: 6vw;
 }
 
 // For "Survey," numbered list numbers, etc.

--- a/src/scss/_tools.typography.scss
+++ b/src/scss/_tools.typography.scss
@@ -1,5 +1,7 @@
 @mixin headline-1 {
-  font-family: 'Whitney SSm A';
+  font-family: "Gotham SSm A", "Gotham SSm B", sans-serif;
+  font-style: normal;
+  font-weight: 800;
   text-align: center;
   margin: 0;
   font-size: 10vw;
@@ -40,7 +42,7 @@
 
 // For "Survey," numbered list numbers, etc.
 @mixin accent-font {
-  font-family: 'Yellowtail';
+  font-family: 'Yellowtail', sans-serif;
   text-align: center;
   font-size: 25vmin;
   color: $blue;
@@ -59,7 +61,7 @@
 }
 
 @mixin headline-2 {
-  font-family: 'Whitney SSm A';
+  font-family: "Whitney SSm A", "Whitney SSm B", sans-serif;
   color: $white;
   font-size: 5rem;
   line-height: 4.5rem;
@@ -75,7 +77,9 @@
 
 // Table of contents
 @mixin headline-4 {
-  font-family: 'Whitney SSm A';
+  font-family: "Gotham SSm A", "Gotham SSm B", sans-serif;
+  font-style: normal;
+  font-weight: 800;
   color: $white;
   font-size: 1.875rem;
 }
@@ -85,7 +89,7 @@
 }
 
 @mixin headline-5 {
-  font-family: 'Whitney SSm A';
+  font-family: "Whitney SSm A", "Whitney SSm B", sans-serif;
   color: $white;
   font-size: 1.75rem;
   font-weight: 300;
@@ -98,7 +102,7 @@
 
 @mixin body-copy($color: inherit) {
   color: $color;
-  font-family: 'Whitney SSm A';
+  font-family: "Whitney SSm A", "Whitney SSm B", sans-serif;
   font-size: 1.5rem;
   font-weight: 300;
   line-height: 2rem;

--- a/src/scss/_tools.typography.scss
+++ b/src/scss/_tools.typography.scss
@@ -1,0 +1,109 @@
+@mixin headline-1 {
+  font-family: 'Whitney SSm A';
+  text-align: center;
+  margin: 0;
+  font-size: 10vw;
+
+  [data-text] {
+    font-family: inherit;
+    color: #F448AF;
+
+    @supports (background-clip: text) {
+      position: relative;
+      text-transform: uppercase;
+      display: inline-block;
+      -webkit-text-stroke: 1px #EEABEF;
+      filter: drop-shadow(0 0.0625em 0 #8D0429);
+
+      &::before {
+        position: absolute;
+        content: attr(data-text);
+        color: rgba(0,0,0,0);
+        display: block;
+        top: 0;
+        background: linear-gradient(0deg, #F448AF 21%, #4A062F 42%, #11161C 43%, #D2F0FD 45%, #146C8C 63%, #082534 77%);
+        background-clip: text;
+        z-index: 2;
+      }
+    }
+  }
+}
+
+.headline-1 {
+  @include headline-1;
+}
+
+.headline-1--small {
+  @include headline-1;
+  font-size: 8vw;
+}
+
+// For "Survey," numbered list numbers, etc.
+@mixin accent-font {
+  font-family: 'Yellowtail';
+  text-align: center;
+  font-size: 25vmin;
+  color: $blue;
+  transform: rotate(-10deg);
+  text-shadow:
+    0 0 0.075em rgba($blue, 0.6),
+    0 0.02em 0 darken($blue, 32%),
+    -0.0075em 0.005em 0 $white,
+    0.01em 0.005em 0 $white,
+    0 0 0.01em black
+    ;
+}
+
+.accent-font {
+  @include accent-font;
+}
+
+@mixin headline-2 {
+  font-family: 'Whitney SSm A';
+  color: $white;
+  font-size: 5rem;
+  line-height: 4.5rem;
+  text-shadow: 0 2px 64px #11161C, 0 2px 4px #11161C, 0 2px 30px #11161C;
+}
+
+.headline-2 {
+  @include headline-2;
+}
+
+// For callouts
+@mixin headline-3 {}
+
+// Table of contents
+@mixin headline-4 {
+  font-family: 'Whitney SSm A';
+  color: $white;
+  font-size: 1.875rem;
+}
+
+.headline-4 {
+  @include headline-4;
+}
+
+@mixin headline-5 {
+  font-family: 'Whitney SSm A';
+  color: $white;
+  font-size: 1.75rem;
+  font-weight: 300;
+  line-height: 2.375rem;
+}
+
+.headline-5 {
+  @include headline-5;
+}
+
+@mixin body-copy($color: inherit) {
+  color: $color;
+  font-family: 'Whitney SSm A';
+  font-size: 1.5rem;
+  font-weight: 300;
+  line-height: 2rem;
+}
+
+.body-copy {
+  @include body-copy;
+}

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -38,6 +38,7 @@
 //    partials in this section.
 
 @import "tools.mixins.general";
+@import "tools.typography";
 
 // =====================================================================
 // 3. Generic


### PR DESCRIPTION
### Description
Add font links to head using [react helmet](https://www.gatsbyjs.org/docs/custom-html/#inserting-html-into-the-head) (best choice based on Gatsby docs and stackoverflow research). 
Add typography mixins and classes.

### To test
#### Font links
1. Go to localhost:8000, open dev tools, make sure the fonts are listed in the `<head>`:
![fonts](https://user-images.githubusercontent.com/23404383/58260486-8a1e4b00-7d44-11e9-89dd-48c3adabfbaf.jpg)
2. You can also update the `base.scss` file to include `font-family: 'Yellowtail';` or `font-family: 'Whitney SSm A';` on the `<body>` to see the font working

#### Typography mixins/classes
1. Check that the text styles on the index page (localhost:8000) work and match [the design](https://sparkbox.invisionapp.com/d/main#/console/17598448/365064738/inspect)