### PR TITLE
DSS-67 feat: learn more link style, add link to CSV download

### DIFF
--- a/src/scss/_components.typography.scss
+++ b/src/scss/_components.typography.scss
@@ -100,3 +100,48 @@
   font-weight: 300;
   line-height: 1.5;
 }
+
+.font-link {
+  font-family: $font-body;
+  font-weight: 700;
+  font-size: 2.125rem;
+  line-height: 1.2;
+  color: $blue;
+  border-bottom: 2px solid $blue;
+  display: inline-block;
+  margin: 0.75em 0;
+  position: relative;
+
+  @supports (background-clip: text) {
+    color: transparent;
+    border-bottom: none;
+    background-image: linear-gradient(90deg, $blue 0%, $green 50%, $blue 100%);
+    background-clip: text;
+    background-size: 250% 100%;
+  }
+
+  &::after {
+    content: '';
+    background: linear-gradient(to right, $blue, $green);
+    position: absolute;
+    top: calc(100% + 0.025rem);
+    left: 0;
+    right: 0;
+    height: 2px;
+    transition: opacity 150ms;
+  }
+
+  &:hover {
+    animation: animated-gradient 1000ms linear alternate infinite;
+
+    &::after {
+      opacity: 0;
+      transition: opacity 150ms;
+    }
+  }
+}
+
+@keyframes animated-gradient {
+	0% {background-position: 0% 0%;}
+	100% {background-position: 100% 100%;}
+}

--- a/src/sections/section-5.mdx
+++ b/src/sections/section-5.mdx
@@ -17,7 +17,7 @@ Read more articles on building, using, and maintaining a design system from the 
 
 Are you looking for help building, adjusting, or maintaining your design system? [Reach out to us for more information on how we can help!][3]
 
-Or are you interested in the full data set of this survey to run your own analysis? [Download the CSV file on Dropbox.][4]
+Or are you interested in the full data set of this survey to run your own analysis? <a class="font-link" href="https://www.dropbox.com/s/8jkacbyvs1ginfi/2019%20Design%20Systems%20Survey%20Shared%20Results.xlsx?dl=0">Download the CSV file on Dropbox.</a>
 
 </ContentBlock>
 
@@ -29,12 +29,11 @@ Or are you interested in the full data set of this survey to run your own analys
 
 <ContentBlock>
 
-The 2019 Design Systems Survey is just the start! We will continue to reflect and write on our findings and share additional articles and insights about design systems in the future. [Sign up to receive updates about Design Systems][5].
+The 2019 Design Systems Survey is just the start! We will continue to reflect and write on our findings and share additional articles and insights about design systems in the future. [Sign up to receive updates about Design Systems][4].
 
 </ContentBlock>
 
 [1]: https://seesparkbox.com "Sparkbox Website Homepage"
 [2]: https://seesparkbox.com/foundry "Sparbox Website Foundry Page"
 [3]: https://seesparkbox.com/work-with-us "Sparkbox Website Work With Us Page"
-[4]: https://www.dropbox.com
-[5]: http://eepurl.com/dta0D1 "Signup Form on the MailChimp Website"
+[4]: http://eepurl.com/dta0D1 "Signup Form on the MailChimp Website"


### PR DESCRIPTION
### Description
Adds additional gradient link style and transition effect. Also adds the link to the CSV file as [the card](https://sparkbox.atlassian.net/secure/RapidBoard.jspa?rapidView=61&projectKey=DSS&modal=detail&selectedIssue=DSS-67) originally requested.

### Comment on HTML in MDX files decision
Here's my logic on adding this link as HTML in the MDX file. I did some research to see if I could add classes to MDX elements, and found that I can with [a plugin](https://github.com/martypdx/rehype-add-classes), however, it will add the class to every single one of those elements.

So to add a class to these "learn more" links at the end of the page means adding that class to all the links on the page, which means overriding something with HTML anyway. There are fewer of these links than other links on the page, so I chose to customize these with HTML.

