### PR TITLE
DSS-8 feat: custom 404 page

### DIFF
--- a/src/components/content-block.js
+++ b/src/components/content-block.js
@@ -1,13 +1,14 @@
 import React from "react"
 import PropTypes from "prop-types"
 
-const ContentBlock = ({ children }) => (
-  <div className="obj-layout-content-max-width">
+const ContentBlock = ({ isFlexbox, children }) => (
+  <div className={"obj-layout-content-max-width " + (isFlexbox ? 'obj-layout-flexbox-center-vrt': '')}>
     {children}
   </div>
 )
 
 ContentBlock.propTypes = {
+  isFlexbox: PropTypes.bool,
   children: PropTypes.node.isRequired,
 }
 

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,13 +1,20 @@
 import React from "react"
 
 import Layout from "../components/layout"
-import SEO from "../components/seo"
+import ContentBlock from "../components/content-block"
 
 const NotFoundPage = () => (
   <Layout>
-    <SEO title="404: Not found" />
-    <h1>NOT FOUND</h1>
-    <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
+    <ContentBlock>
+      <div className="obj-layout-flexbox-center-vrt">
+        <section className="cmp-404">
+          <h1 className="cmp-404__title">404 Error</h1>
+          <h3 className="cmp-404__description">We can't seem to find the page you're looking for.</h3>
+          <p>Were you looking for this year's <a href="#">Design System Survey results</a>?</p>
+          <p>Or maybe <a href="#">last year's results</a>?</p>
+        </section>
+      </div>
+    </ContentBlock>
   </Layout>
 )
 

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -5,15 +5,13 @@ import ContentBlock from "../components/content-block"
 
 const NotFoundPage = () => (
   <Layout>
-    <ContentBlock>
-      <div className="obj-layout-flexbox-center-vrt">
-        <section className="cmp-404">
-          <h1 className="cmp-404__title">404 Error</h1>
-          <h3 className="cmp-404__description">We can't seem to find the page you're looking for.</h3>
-          <p>Were you looking for this year's <a href="#">Design System Survey results</a>?</p>
-          <p>Or maybe <a href="#">last year's results</a>?</p>
-        </section>
-      </div>
+    <ContentBlock isFlexbox="true">
+      <section className="cmp-404">
+        <h1 className="cmp-404__title">404 Error</h1>
+        <h3 className="cmp-404__description">We can't seem to find the page you're looking for.</h3>
+        <p>Were you looking for this year's <a href="#">Design System Survey results</a>?</p>
+        <p>Or maybe <a href="#">last year's results</a>?</p>
+      </section>
     </ContentBlock>
   </Layout>
 )

--- a/src/pages/chart.mdx
+++ b/src/pages/chart.mdx
@@ -1,6 +1,0 @@
-import Chart2a from "../components/diagram-2a-chart"
-import Layout from "../components/layout"
-
-<Layout>
-  <Chart2a />
-</Layout>

--- a/src/scss/_components.404.scss
+++ b/src/scss/_components.404.scss
@@ -1,0 +1,21 @@
+.cmp-404 {
+  &__title {
+    font-family: $font-heading;
+    color: $white;
+    font-size: 5rem;
+    line-height: 1;
+    text-transform: uppercase;
+    text-shadow: 0 2px 64px $black, 0 2px 4px $black, 0 2px 30px $black;
+    hyphens: auto;
+  }
+
+  &__description {
+    font-family: $font-heading;
+    font-style: normal;
+    font-weight: 700;
+    font-size: 2.75rem;
+    line-height: 1.2;
+    text-shadow: 0 0 0.375rem 0 rgba($yellow, 0.2);
+    color: $white;
+  }
+}

--- a/src/scss/_objects.layout.flexbox.scss
+++ b/src/scss/_objects.layout.flexbox.scss
@@ -1,0 +1,6 @@
+.obj-layout-flexbox-center-vrt {
+  display: flex;
+  align-items: center;
+  height: 100vh;
+  min-height: 30rem;
+}

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -67,13 +67,15 @@
 //    Class-based selectors which define undecorated design patterns,
 //    for example media object known from OOCSS.
 
-@import "objects.layout.max-width.scss";
+@import "objects.layout.flexbox";
+@import "objects.layout.max-width";
 
 // =====================================================================
 // 6. Components
 //    Specific UI components. This is where majority of our work takes place
 //    and our UI components are often composed of Objects and Components
 
+@import "components.404";
 @import "components.diagram.table";
 @import "components.diagram.chart";
 @import "components.typography";


### PR DESCRIPTION
### Description
Add custom 404 page

### To test
Per [Gatsby.js docs](https://www.gatsbyjs.org/docs/add-404-page/), "when developing, Gatsby adds a default 404 page that overrides your custom 404 page. But you can still preview your 404 page by clicking “Preview custom 404 page” to verify that it’s working as expected."