### PR TITLE
DSS-81 fix: edge character bug

### DIFF
--- a/src/components/diagram-4a.js
+++ b/src/components/diagram-4a.js
@@ -75,9 +75,9 @@ const Diagram4a = () => (
       <div className="cmp-row-chart__secondary">
         <h5 className="util-visually-hidden">Chart Key</h5>
         <ul className="cmp-key">
-          <TableKey color="hotpink" text="On a standalone documentation  site where users primarily  copy + paste" />
-          <TableKey color="yellow" text="In a external codebase and consumed by the main  codebase’s build pipeline" />
-          <TableKey color="blue" text="In an external codebase and  consumed via package" />
+          <TableKey color="hotpink" text="On a standalone documentation site where users primarily copy + paste" />
+          <TableKey color="yellow" text="In a external codebase and consumed by the main codebase’s build pipeline" />
+          <TableKey color="blue" text="In an external codebase and consumed via package" />
           <TableKey color="green" text="Included in the main codebase" />
           <TableKey color="orange" text="I am not sure" />
           <TableKey color="white" text="Other" />


### PR DESCRIPTION
Thinking this may have been cased by copying content over from Google Docs/Sheets. I found these weird little symbols (shown below) when I looked at the chart file in VS Code, so I removed those and then the LSEP character was gone in Edge. ¯\_(ツ)_/¯

![lsep-before](https://user-images.githubusercontent.com/23404383/60604807-5c3a1680-9d86-11e9-8bf8-51114c27dac0.jpg)
