### PR TITLE
DSS-90 : Improve accessibility of charts / tables

### DIFF
--- a/src/components/diagram-3a.js
+++ b/src/components/diagram-3a.js
@@ -12,11 +12,11 @@ const Diagram3a = () => (
         <thead>
           <tr>
             <th>&nbsp;</th>
-            <th>1</th>
-            <th>2</th>
-            <th>3</th>
-            <th>4</th>
-            <th>5</th>
+            <th aria-label="not a motivator">1</th>
+            <th aria-label="a low motivator">2</th>
+            <th aria-label="neutral">3</th>
+            <th aria-label="a moderate motivator">4</th>
+            <th aria-label="a strong motivator">5</th>
           </tr>
         </thead>
         <tbody>

--- a/src/scss/_components.diagram.scss
+++ b/src/scss/_components.diagram.scss
@@ -8,19 +8,29 @@
     max-width: $max-width;
     margin: 2rem auto;
     overflow: auto;
-    display: none;
+    @include visually-hidden;
 
     &:focus {
       position: inherit !important;
       width: auto !important;
       height: auto !important;
+
+      + .cmp-row-chart,
+      + .cmp-diagram__chart {
+        display: none !important; // When the table receives focus, hide the chart.
+      }
+    }
+
+    @media (min-width: $bp-md) {
+      @include visually-hidden;
     }
 
     &--vertical {
+      @include visually-hidden(disable);
       display: block;
 
       @media (min-width: $bp-md) {
-        display: none;
+        @include visually-hidden;
       }
     }
 


### PR DESCRIPTION
# [DSS-90](https://sparkbox.atlassian.net/browse/DSS-90)
The work in this PR improves accessibility by displaying the table version of all charts when a user tabs through the site.

## To test
Run the project locally `gatsby develop`
Go to `localhost:8000`

Scrolling through the site at small and large screen sizes, you should not see any changes. Everything should look exactly the same. At small screen sizes you should see bar charts and tables. At large screen sizes you should see bar and cylinder charts.

Previously when tabbing through content while using a screen reader, the charts were skipped over. Now when tabbing through the site all charts should be hidden while their table counterpart is displayed.

- [x] Scroll through the site a small and large screen sizes to confirm all content is presented in the correct chart and table formats.
- [x] Tab through the site. Tables will receive focus due to a `tabIndex` of zero.
- [x] Use VoiceOver to verify all content is accessible.

The presentation of content within the table which features the scale of 1 to 5 has been improved by adding `aria-labels` to the table column headings to assist with identifying each the number with its associated level of motivation.

<img width="1083" alt="table" src="https://user-images.githubusercontent.com/12678977/61231282-d90baf80-a6f9-11e9-8218-e0adca575503.png">

