### PR TITLE
DSS-97 fix: hide pipe decoration from screen readers

### DIFF
--- a/src/components/diagram-2a.js
+++ b/src/components/diagram-2a.js
@@ -16,7 +16,7 @@ class Diagram2a extends Component {
     return (
       <section className="cmp-diagram">
         <p id="table2a" className="font-diagram-heading">Q: How is your design system delivered to the consumers of the design system?</p>
-        <p className="font-diagram-copy">108 In-House Responses | Respondents were asked to select one&nbsp;answer</p>
+        <p className="font-diagram-copy">108 In-House Responses <span aria-hidden="true">|</span> Respondents were asked to select one&nbsp;answer</p>
         <div className="cmp-diagram__table cmp-diagram__table--vertical" tabIndex="0">
           <table aria-labelledby="table2a">
             <tbody>

--- a/src/components/diagram-3a.js
+++ b/src/components/diagram-3a.js
@@ -6,7 +6,7 @@ import TableColumn from "./diagram-table-column"
 const Diagram3a = () => (
   <section className="cmp-diagram">
     <p id="table3a" className="font-diagram-heading">Q: How strongly did each of the following factors motivate your organization to establish a design system?</p>
-    <p className="font-diagram-copy">108 In-House Responses | Respondents were asked to rate on a 1 to 5 scale where 1= Not a motivator and 5= A strong&nbsp;motivator</p>
+    <p className="font-diagram-copy">108 In-House Responses <span aria-hidden="true">|</span> Respondents were asked to rate on a 1 to 5 scale where 1= Not a motivator and 5= A strong&nbsp;motivator</p>
     <div className="cmp-diagram__table" tabIndex="0">
       <table aria-labelledby="table3a">
         <thead>

--- a/src/components/diagram-3b.js
+++ b/src/components/diagram-3b.js
@@ -16,7 +16,7 @@ class Diagram3b extends Component {
     return (
       <section className="cmp-diagram">
         <p id="table3b" className="font-diagram-heading">Q: What about a client engagement leads you to suggest or not suggest a design system?</p>
-        <p className="font-diagram-copy">79 Agency Responses | Respondents were asked to select all that&nbsp;apply</p>
+        <p className="font-diagram-copy">79 Agency Responses <span aria-hidden="true">|</span> Respondents were asked to select all that&nbsp;apply</p>
         <div className="cmp-diagram__table cmp-diagram__table--vertical" tabIndex="0">
           <table aria-labelledby="table3b">
           <tbody>

--- a/src/components/diagram-3c.js
+++ b/src/components/diagram-3c.js
@@ -16,7 +16,7 @@ class Diagram3c extends Component {
     return (
       <section className="cmp-diagram">
         <p id="table3c" className="font-diagram-heading">Q: If you feel that your organization’s design system was not successful, what were the primary reasons?</p>
-        <p className="font-diagram-copy">71 In-House Responses | Respondents were asked to select all that&nbsp;apply</p>
+        <p className="font-diagram-copy">71 In-House Responses <span aria-hidden="true">|</span> Respondents were asked to select all that&nbsp;apply</p>
         <div className="cmp-diagram__table cmp-diagram__table--vertical" tabIndex="0">
           <table aria-labelledby="table3c">
           <tbody>

--- a/src/components/diagram-4a.js
+++ b/src/components/diagram-4a.js
@@ -6,7 +6,7 @@ import TableColumn from "./diagram-table-column"
 const Diagram4a = () => (
   <section className="cmp-diagram">
     <p id="table4a" className="font-diagram-heading">Q: How is your design system delivered to the consumers of the design system?</p>
-    <p className="font-diagram-copy">108 In-House Responses | Respondents were asked to select one&nbsp;answer</p>
+    <p className="font-diagram-copy">108 In-House Responses <span aria-hidden="true">|</span> Respondents were asked to select one&nbsp;answer</p>
 
     <div className="cmp-diagram__table" tabIndex="0">
       <table aria-labelledby="table4a">

--- a/src/components/diagram-4b.js
+++ b/src/components/diagram-4b.js
@@ -6,7 +6,7 @@ import TableColumn from "./diagram-table-column"
 const Diagram4b = () => (
   <section className="cmp-diagram">
     <p id="table4b" className="font-diagram-heading">Q: How much of your website(s) or application(s) is sourced from your design system?</p>
-    <p className="font-diagram-copy">108 In-House Responses | Respondents were asked to select one&nbsp;answer</p>
+    <p className="font-diagram-copy">108 In-House Responses <span aria-hidden="true">|</span> Respondents were asked to select one&nbsp;answer</p>
     <div className="cmp-diagram__table" tabIndex="0">
       <table aria-labelledby="table4b">
         <thead>


### PR DESCRIPTION
Uses `aria-hidden` to hide decorative pipe from screen readers.