### PR TITLE
DSS-104 : update header tags for proper semantics and improved accessibility

### DIFF
--- a/src/components/top-tools-list.js
+++ b/src/components/top-tools-list.js
@@ -3,8 +3,8 @@ import React from "react"
 const TopToolsList = () => (
   <section className="obj-layout-max-width cmp-feature-list__flex">
     <div className="cmp-feature-list__container">
-      <h4 className="cmp-feature-list__title">Designer or User Experience</h4>
-      <h5 className="cmp-feature-list__description">146 Responses</h5>
+      <h3 className="cmp-feature-list__title">Designer or User Experience</h3>
+      <h4 className="cmp-feature-list__description">146 Responses</h4>
       <ol className="cmp-feature-list">
         <li className="cmp-feature-list__item"><span>InVision Design System Manager&nbsp;<mark className="util-italic">60 responses</mark></span></li>
         <li className="cmp-feature-list__item"><span>Storybook&nbsp;<mark className="util-italic">38 responses</mark></span></li>
@@ -15,8 +15,8 @@ const TopToolsList = () => (
     </div>
 
     <div className="cmp-feature-list__container">
-      <h4 className="cmp-feature-list__title">Developer</h4>
-      <h5 className="cmp-feature-list__description">117 Responses</h5>
+      <h3 className="cmp-feature-list__title">Developer</h3>
+      <h4 className="cmp-feature-list__description">117 Responses</h4>
       <ol className="cmp-feature-list">
         <li className="cmp-feature-list__item"><span>Storybook&nbsp;<mark className="util-italic">47 responses</mark></span></li>
         <li className="cmp-feature-list__item"><span>Pattern Lab&nbsp;<mark className="util-italic">26 responses</mark></span></li>

--- a/src/components/useful-feature-list.js
+++ b/src/components/useful-feature-list.js
@@ -3,7 +3,7 @@ import React from "react"
 const UsefulFeatureList = () => (
   <section className="obj-layout-max-width cmp-feature-list__flex">
     <div className="cmp-feature-list__container">
-      <h4 className="cmp-feature-list__title">Designer or User Experience</h4>
+      <h3 className="cmp-feature-list__title">Designer or User Experience</h3>
       <ol className="cmp-feature-list">
         <li className="cmp-feature-list__item"><span>Color System</span></li>
         <li className="cmp-feature-list__item"><span>Typography System</span></li>
@@ -14,7 +14,7 @@ const UsefulFeatureList = () => (
     </div>
 
     <div className="cmp-feature-list__container">
-      <h4 className="cmp-feature-list__title">Developer</h4>
+      <h3 className="cmp-feature-list__title">Developer</h3>
       <ol className="cmp-feature-list">
         <li className="cmp-feature-list__item"><span>Color System</span></li>
         <li className="cmp-feature-list__item"><span>Spacing System&nbsp;<mark className="util-italic">tie</mark></span></li>


### PR DESCRIPTION
# [DSS-104](https://sparkbox.atlassian.net/browse/DSS-104)

Updated header tags to eliminate jumps from `<h2>` to `<h4>`.

## To test
Spin up your local dev environment with `gatsby develop` and go to `http://localhost:8000/`

There are two ways you can test this PR:

1) Activate VoiceOver. `Command + Fn + F5`
    Press `Option + Control + U` to open up the web item rotor. Use the left and right arrow keys to find the `Headings Menu`. Scan through the headings to confirm they are in semantic order with no heading levels skipped over.

2) Go to `http://localhost:8000/` in Chrome.
    Open `Developer Tools`
    Go to the `Audits` tab
    Under `Audits` select `Accessibility`
    Run the audit.
    There should not be any heading structure errors.
