### PR TITLE
DSS-100 : Adjust vw size of the Table of Contents header to prevent horizontal scroll at 200%

### DIFF
--- a/src/components/table-of-contents.js
+++ b/src/components/table-of-contents.js
@@ -2,7 +2,7 @@ import React from "react"
 
 const TableOfContents = () => (
   <div className="cmp-table-of-contents" id="table-of-contents">
-    <h2 className="font-chrome font-chrome--small">Table of Contents</h2>
+    <h2 className="cmp-table-of-contents__title">Table of Contents</h2>
     <div className="cmp-table-of-contents__items">
       <ol className="cmp-table-of-contents__list">
         <li className="cmp-table-of-contents__item"><a href="#section-1" className="font-label cmp-table-of-contents__link">The Respondents</a></li>

--- a/src/scss/_components.table-of-contents.scss
+++ b/src/scss/_components.table-of-contents.scss
@@ -1,9 +1,49 @@
 .cmp-table-of-contents {
   padding: 1rem;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  &__title {
+    font-family: $font-heading;
+    font-style: normal;
+    font-weight: 800;
+    line-height: 1;
+    text-transform: uppercase;
+    text-align: center;
+    text-shadow: 0 0 0.375rem 0 rgba($yellow, 0.2);
+    color: $hotpink;
+
+    font-size: 2rem;
+
+    @media (min-width: $bp-xs) {
+      font-size: 6.5vw;
+    }
+
+    @media (min-width: $bp-lg) {
+      font-size: 5rem;
+    }
+
+    @supports (background-clip: text) {
+      position: relative;
+      color: transparent;
+      top: 0;
+      background-image: linear-gradient(180deg, $hotpink 0%, $yellow 100%);
+      background-clip: text;
+      z-index: 2;
+    }
+
+    @include print {
+      color: $hotpink;
+      text-shadow: none;
+    }
+  }
 
   &__items {
     max-width: 71rem;
-    margin: 6rem auto;
+    margin: 2rem auto;
 
     @media (min-width: $bp-md) {
       display: flex;
@@ -40,7 +80,7 @@
     display: flex;
     align-items: center;
     margin: 0.5rem 0;
-    max-width: 100%;
+    width: 100%;
 
     @media (min-width: $bp-md) {
       padding-left: 1rem;
@@ -49,14 +89,39 @@
     &::before {
       @include number;
       content: counter(count);
+      display: block;
+      text-align: right;
+      width: 3rem;
     }
   }
 
   &__link {
+    width: 80%;
+    display: block;
     margin-left: 2rem;
+    text-decoration: none;
+    padding: 1rem;
+    border-radius: 0.25rem;
+    border: 1px solid lighten($black, 10%);
+    box-sizing: border-box;
+
+    .safe-focus &:focus,
+    &:focus,
+    &:hover {
+      border-color: $white;
+    }
 
     &:hover {
-      text-decoration: none;
+      animation: toc-link-glow 1s ease-in-out alternate infinite;
     }
+  }
+}
+
+@keyframes toc-link-glow {
+  from {
+    box-shadow: 0 0 0.25rem rgba($blue, 0.5), 0 0 0.25rem rgba($blue, 0.5) inset;
+  }
+  to {
+    box-shadow: 0 0 0.5rem rgba($blue, 1), 0 0 0.5rem rgba($blue, 1) inset;
   }
 }

--- a/src/scss/_components.typography.scss
+++ b/src/scss/_components.typography.scss
@@ -21,10 +21,10 @@
   }
 
   &--small {
-    font-size: 1.5rem;
+    font-size: 2rem;
 
     @media (min-width: $bp-xs) {
-      font-size: 8vw;
+      font-size: 6.5vw;
     }
 
     @media (min-width: $bp-lg) {


### PR DESCRIPTION
# [DSS-100](https://sparkbox.atlassian.net/browse/DSS-100)

It appears that Safari has issues recalculating `vw` units upon zoom. The size of the `Table of Contents` header has been reduced a touch to prevent horizontal scroll when the browser is zoomed in to 200%. 

### To test
After running `gatsby develop` to start up a local dev environment, go to `localhost:8000` in Safari. Using the `Command and +` keys zoom out to 200%. Confirm there is no horizontal scroll. Note that if you zoom past 200%, you will get the horizontal scroll. 200% is the threshold for passing [WCAG Success Criterion 1.4.4](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-scale.html).

Test in additional browsers to confirm no new bugs have been introduced.