### PR TITLE
DSS-88 : refactor respondent shapes to render in all browsers

### DIFF
--- a/src/scss/_components.respondents.scss
+++ b/src/scss/_components.respondents.scss
@@ -138,17 +138,23 @@
 
         .cmp-pyramid {
           --size: 10rem;
+          // Explicitly set values to be used in the pyramid's transform along the z-axis to ensure correct rendering in Edge
+          --z-axis: -9.38rem; // calc(-0.938 * var(--size))
+
 
           @media (min-width: $bp-respond-medium-layout) {
             --size: 20rem;
+            --z-axis: -18.76rem;
           }
 
           @media (min-width: $bp-respond-size-bump-medium) {
             --size: 23rem;
+            --z-axis: -21.574rem;
           }
 
           @media (min-width: $bp-respond-size-bump-large) {
             --size: 28rem;
+            --z-axis: -26.264rem;
           }
         }
       }
@@ -175,7 +181,7 @@
           left: calc(100% - 33rem);
         }
 
-        .cmp-cube{
+        .cmp-cube {
           --size: 8rem;
 
           @media (min-width: $bp-respond-medium-layout) {
@@ -214,7 +220,7 @@
           left: calc(100% - 19rem);
         }
 
-        .cmp-diamond{
+        .cmp-diamond {
           --size: 7rem;
 
           @media (min-width: $bp-respond-stop-overlap) {
@@ -255,7 +261,7 @@
           left: calc(100% - 14.5rem);
         }
 
-        .cmp-dodecahedron{
+        .cmp-dodecahedron {
           --size: 5rem;
 
           @media (min-width: $bp-respond-medium-layout) {

--- a/src/scss/_components.respondents.scss
+++ b/src/scss/_components.respondents.scss
@@ -272,17 +272,33 @@
 
         .cmp-dodecahedron {
           --size: 5rem;
+          --top-z-axis: -4.375rem; // calc(var(--size) * -0.875);
+          --bottom-z-axis: -3.375rem; // calc(var(--size) * -0.675);
+          --side-z-axis: 0.25rem; // calc(var(--size) * 0.05);
+          --moveX: 2.5rem; // calc(var(--size) * 0.5);
 
           @media (min-width: $bp-respond-medium-layout) {
             --size: 2.25rem;
+            --top-z-axis: -1.96875rem;
+            --bottom-z-axis: -1.51875rem;
+            --side-z-axis: 0.1125rem;
+            --moveX: 1.125rem;
           }
 
           @media (min-width: $bp-respond-size-bump-medium) {
             --size: 2.75rem;
+            --top-z-axis: -2.40625rem;
+            --bottom-z-axis: -1.85625rem;
+            --side-z-axis: 0.1375rem;
+            --moveX: 1.375rem;
           }
 
           @media (min-width: $bp-respond-size-bump-large) {
             --size: 4rem;
+            --top-z-axis: -3.5rem;
+            --bottom-z-axis: -2.7rem;
+            --side-z-axis: 0.2rem;
+            --moveX: 2rem;
           }
         }
       }

--- a/src/scss/_components.respondents.scss
+++ b/src/scss/_components.respondents.scss
@@ -222,21 +222,26 @@
 
         .cmp-diamond {
           --size: 7rem;
+          --bottom-z-axis: -13.195rem; // calc(var(--size) * -1.885);
 
           @media (min-width: $bp-respond-stop-overlap) {
             --size: 6rem;
+            --bottom-z-axis: -11.31rem;
           }
 
           @media (min-width: $bp-respond-medium-layout) {
             --size: 3.5rem;
+            --bottom-z-axis: -6.5975rem;
           }
 
           @media (min-width: $bp-respond-size-bump-medium) {
             --size: 5rem;
+            --bottom-z-axis: -9.425rem;
           }
 
           @media (min-width: $bp-respond-size-bump-large) {
             --size: 7rem;
+            --bottom-z-axis: -13.195rem;
           }
         }
       }

--- a/src/scss/_components.respondents.scss
+++ b/src/scss/_components.respondents.scss
@@ -183,17 +183,21 @@
 
         .cmp-cube {
           --size: 8rem;
+          --z-axis: -8rem; // calc(var(--size) * -1);
 
           @media (min-width: $bp-respond-medium-layout) {
             --size: 12rem;
+            --z-axis: -12rem;
           }
 
           @media (min-width: $bp-respond-size-bump-medium) {
             --size: 14rem;
+            --z-axis: -14rem;
           }
 
           @media (min-width: $bp-respond-size-bump-large) {
             --size: 16rem;
+            --z-axis: -16rem;
           }
         }
       }

--- a/src/scss/_components.shape.cube.scss
+++ b/src/scss/_components.shape.cube.scss
@@ -3,8 +3,7 @@
   width: 100%;
   background: svg('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 84" ><rect fill="#{mix($yellow, $black, 20%)}" stroke="#{$yellow}" stroke-width="3px" vector-effect="non-scaling-stroke" x="0" y="0" height="84" width="84" /></svg>') no-repeat left center / contain;
 
-  @supports(transform-style: preserve-3d) {
-    --rotate: 45deg;
+  @supports (transform-style: preserve-3d) {
 
     height: var(--size);
     width: var(--size);
@@ -29,8 +28,7 @@
       transform-origin: center;
       transform:
         rotateX(var(--shape-angle))
-        rotateZ(var(--rotate))
-      ;
+        rotateZ(45deg);
       perspective-origin: center;
 
       .cmp-respondents--animated & {
@@ -69,7 +67,7 @@
       }
 
       &--6 {
-        transform: translateZ(calc(var(--size) * -1));
+        transform: translateZ(var(--z-axis));
         transform-origin: center center;
       }
     }
@@ -81,7 +79,7 @@
   to {
     transform:
       rotateX(var(--shape-angle))
-      rotateZ(calc(var(--rotate) + 360deg));
+      rotateZ(405deg);
   }
 }
 

--- a/src/scss/_components.shape.diamond.scss
+++ b/src/scss/_components.shape.diamond.scss
@@ -3,7 +3,7 @@
   width: 100%;
   background: svg('<svg width="87" height="150" viewBox="0 0 87 150"><path fill="#{mix($green, $black, 20%)}" stroke="#{$green}" stroke-width="1.5" vector-effect="non-scaling-stroke" d="M87 75l-43.5 75L0 75 43.5 0z"/></svg>') no-repeat left center / contain;
 
-  @supports(transform-style: preserve-3d) {
+  @supports (transform-style: preserve-3d) {
     --height: var(--size);
     --width: calc(var(--size) * 1.16);
 

--- a/src/scss/_components.shape.diamond.scss
+++ b/src/scss/_components.shape.diamond.scss
@@ -7,7 +7,6 @@
     --height: var(--size);
     --width: calc(var(--size) * 1.16);
 
-    --rotate: 70deg;
     --offset: calc(var(--size) * -0.5);
 
     height: calc(var(--height) * 1.625);
@@ -32,7 +31,7 @@
       transform-origin: 50% 50%;
       transform:
         rotateX(var(--shape-angle))
-        rotateZ(var(--rotate));
+        rotateZ(70deg);
       perspective-origin: center;
 
       .cmp-respondents--animated & {
@@ -44,11 +43,11 @@
       transform-style: preserve-3d;
 
       &--top {
-        transform: translateZ(calc(var(--height) * 0));
+        transform: translateZ(0);
       }
 
       &--bottom {
-        transform: translateZ(calc(var(--height) * -1.885));
+        transform: translateZ(var(--bottom-z-axis)); // Explicitly declared in components.shape.diamond
       }
     }
 
@@ -88,7 +87,7 @@
 
 @keyframes diamond-spin {
   to {
-    transform: rotateX(var(--shape-angle)) rotateZ(calc(var(--rotate) + 360deg));
+    transform: rotateX(var(--shape-angle)) rotateZ(430deg);
   }
 }
 

--- a/src/scss/_components.shape.dodecahedron.scss
+++ b/src/scss/_components.shape.dodecahedron.scss
@@ -2,15 +2,12 @@
   height: 100%;
   width: 100%;
   background: svg('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 95.11 90.45"><polygon fill="#{mix($orange, $black, 20%)}" stroke="#{$orange}" stroke-width="1.5" vector-effect="non-scaling-stroke" points="47.55 0 0 34.55 18.16 90.45 76.94 90.45 95.11 34.55 47.55 0"/></svg>') no-repeat left center / contain;
-  @supports(transform-style: preserve-3d) {
+  @supports (transform-style: preserve-3d) {
     --height: var(--size);
     --width: calc(var(--size) * 1.16);
 
-    --z: 40deg;
     --move: cacl(var(--size) * -0.5);
 
-    --angle: 116deg;
-    --moveX: calc(var(--height) * 0.5);
     --moveY: calc(var(--width) * 0.575);
 
     background: none;
@@ -33,8 +30,7 @@
       perspective-origin: center;
       transform:
         rotateX(var(--shape-angle))
-        rotateY(var(--z))
-      ;
+        rotateY(40deg);
 
       .cmp-respondents--animated & {
         animation: dodecahedron-spin var(--shape-animation-duration) linear infinite;
@@ -43,7 +39,7 @@
 
     &__top {
       transform-style: preserve-3d;
-      transform: translateZ(calc(var(--height) * -0.875));
+      transform: translateZ(var(--top-z-axis));
     }
 
     &__bottom {
@@ -52,9 +48,9 @@
       transform:
         rotateY(180deg)
         rotateZ(36deg)
-        translateZ(calc(var(--height) * -0.675))
-        translatex(calc(var(--height) * 0.3))
-        translatey(calc(var(--height) * -0.1));
+        translateZ(var(--bottom-z-axis))
+        translateX(calc(var(--height) * 0.3))
+        translateY(calc(var(--height) * -0.1));
     }
 
     &__side {
@@ -67,46 +63,46 @@
       &--1 {
         transform:
           translateY(calc(var(--height) * -0.05))
-          translateZ(calc(var(--height) * 0.05));
+          translateZ(var(--side-z-axis));
       }
 
       &--2 {
         transform:
-          translatez(var(--moveX))
-          translatey(var(--moveY))
-          rotateX(calc(var(--angle) * -1));
+          translateZ(var(--moveX))
+          translateY(var(--moveY))
+          rotateX(-116deg);
       }
 
       &--3 {
         transform:
-        rotatez(-72deg)
-        translatez(var(--moveX))
-        translatey(var(--moveY))
-        rotateX(calc(var(--angle) * -1));
+        rotateZ(-72deg)
+        translateZ(var(--moveX))
+        translateY(var(--moveY))
+        rotateX(-116deg);
       }
 
       &--4 {
         transform:
         rotateZ(-144deg)
-        translatez(var(--moveX))
-        translatey(var(--moveY))
-        rotateX(calc(var(--angle) * -1));
+        translateZ(var(--moveX))
+        translateY(var(--moveY))
+        rotateX(-116deg);
       }
 
       &--5 {
         transform:
         rotateZ(-216deg)
-        translatez(var(--moveX))
-        translatey(var(--moveY))
-        rotateX(calc(var(--angle) * -1));
+        translateZ(var(--moveX))
+        translateY(var(--moveY))
+        rotateX(-116deg);
       }
 
       &--6 {
         transform:
         rotateZ(-288deg)
-        translatez(var(--moveX))
-        translatey(var(--moveY))
-        rotateX(calc(var(--angle) * -1));
+        translateZ(var(--moveX))
+        translateY(var(--moveY))
+        rotateX(-116deg);
       }
     }
   }
@@ -116,8 +112,7 @@
   to {
     transform:
       rotateX(var(--shape-angle))
-      rotateY(calc(var(--z) - 360deg))
-    ;
+      rotateY(-320deg);
   }
 }
 

--- a/src/scss/_components.shape.pyramid.scss
+++ b/src/scss/_components.shape.pyramid.scss
@@ -2,7 +2,7 @@
   height: 100%;
   width: 100%;
   background: svg('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 87 75"><path fill="#{mix($hotpink, $black, 20%)}" stroke="#{$hotpink}" stroke-width="2" vector-effect="non-scaling-stroke" d="M43.5 0L0 75h87L43.5 0z"/></svg>') no-repeat left center / contain;
-  @supports(transform-style: preserve-3d) {
+  @supports (transform-style: preserve-3d) {
     --height: var(--size);
     --width: calc(var(--size) * 1.16);
 

--- a/src/scss/_components.shape.pyramid.scss
+++ b/src/scss/_components.shape.pyramid.scss
@@ -6,7 +6,6 @@
     --height: var(--size);
     --width: calc(var(--size) * 1.16);
 
-    --rotate: 30deg;
     --offset: calc(var(--size) * -0.5);
 
     background: none;
@@ -31,7 +30,7 @@
       transform-origin: 50% 50%;
       transform:
         rotateX(var(--shape-angle))
-        rotateZ(var(--rotate));
+        rotateZ(30deg);
       perspective-origin: center;
 
       .cmp-respondents--animated & {
@@ -72,7 +71,7 @@
     &__side--4 {
       transform:
         translateY(calc(-0.16667 * var(--height)))
-        translateZ(calc(-0.938 * var(--height)));
+        translateZ(var(--z-axis)); // Explicitly declared in components.respondents
     }
   }
 }
@@ -81,7 +80,7 @@
   to {
     transform:
       rotateX(var(--shape-angle))
-      rotateZ(calc(var(--rotate) + 360deg));
+      rotateZ(390deg);
   }
 }
 @keyframes pyramid-pulse {


### PR DESCRIPTION
# [DSS-88](https://sparkbox.atlassian.net/browse/DSS-88)

### The issue
Respondent shapes were not rendering correctly in Edge.

### The solution
It was discovered that the `calc` function does not work as expected when used in `transforms` with the `Z axis`. The codebase was refactored to explicitly declare `z axis` values thus eliminating the use of the `calc` function.

### To test
Go to http://localhost:8000 in multiple browsers to confirm the shapes render correctly.
 - [x] Edge
 - [x] Safari
 - [x] Firefox
 - [x] Chrome