### PR TITLE
DSS-114 fix: add validation to email, wont submit blank input

### DIFF
--- a/src/components/form.js
+++ b/src/components/form.js
@@ -5,7 +5,7 @@ export default class Form extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      email: null,
+      email: false,
       subscribed: false,
       alreadySubscribed: false,
       invalidEmail: false,
@@ -25,6 +25,8 @@ export default class Form extends Component {
       .then(({result, msg}) => {
         if (result !== 'success') {
           if (msg.includes('invalid')) {
+            this.setState({invalidEmail: true});
+          } else if (!this.state.email) {
             this.setState({invalidEmail: true});
           } else {
             this.setState({alreadySubscribed: true});


### PR DESCRIPTION
Before, the form would let you hit "submit" with nothing in the input and give you a "yay you signed up" message. Now it says "invalid" when you try to submit a blank form.