### PR TITLE
DSS-117 : remove charts and update copy for section 4

### DIFF
--- a/src/sections/section-4.mdx
+++ b/src/sections/section-4.mdx
@@ -40,7 +40,16 @@ More often than not, the list of team members was cross-functional, expanding be
 
 </NumberBlock>
 
-<Diagram4a />
+<ContentBlock>
+
+Of respondents with a successful design system, **79%** integrated the design system into the developer's workflow or tooling. The following are how respondents with successful design system deliver it to the consumers of the design system:
+- **49%** deliver their design system by an external codebase and consumed via package
+- **15%** deliver their design system by an external codebase and consumed by the main codebase’s pipeline
+- **15%** deliver the design system in the main codebase 
+
+These delivery models  make the design system a way of life for developers.
+
+</ContentBlock>
 
 <NumberBlock pointNumber="3">
 
@@ -53,5 +62,3 @@ More often than not, the list of team members was cross-functional, expanding be
 Of responders who said they felt their design system was very successful or successful, **62%** were sourcing **50%** or more of their website from the design system. And of those who perceived their design system as very successful, **63%** had over **75%** of their web properties sourced from their design system.
 
 </ContentBlock>
-
-<Diagram4b />


### PR DESCRIPTION
# [DSS-117](https://sparkbox.atlassian.net/browse/DSS-117)

#### Remove charts and update copy for section 4 `Creating a Successful Design System`

Spin up your local development environment by running `gatsby develop`
Go to http://localhost:8000/
Scroll or in the table of contents, click on number 4 to go to the section titled `Creating a Successful Design System`
- [x] Confirm the charts have been removed
- [x] Reference the [2019 Design System Survey Google doc](https://docs.google.com/document/d/1u86wlc3KZcq2_GJCnYWIt6kWw1RelSyh9HWEYXURacA/edit#) to verify that the copy has been updated correctly