### PR TITLE
DSS-119 fix: firefox horizontal scroll caused by chart platform

### DIFF
--- a/src/scss/_components.diagram.chart.scss
+++ b/src/scss/_components.diagram.chart.scss
@@ -73,8 +73,9 @@ $circle-height: 28px;
     perspective: 800px;
     position: absolute;
     top: 22.875rem;
+    left: 1%;
     height: 4.5rem;
-    width: 100%;
+    width: 98%;
     z-index: 0;
 
     @supports (display: grid) {

--- a/src/scss/_components.respondents.scss
+++ b/src/scss/_components.respondents.scss
@@ -2,6 +2,7 @@
   width: calc(100% - 2rem);
   max-width: $max-width;
   margin: 4rem auto 6rem;
+  overflow: hidden;
 
   @media (min-width: $bp-respond-medium-layout) {
     margin: 6rem auto 8rem;

--- a/src/scss/_components.table-of-contents.scss
+++ b/src/scss/_components.table-of-contents.scss
@@ -85,6 +85,7 @@
 
     @media (min-width: $bp-md) {
       padding-left: 1rem;
+      max-width: calc(100% - 1.5rem); // Prevent overflow from padding-left
     }
 
     &::before {


### PR DESCRIPTION
Reverts some CSS changes from #217 to remove the horizontal scrolling in Firefox.