### PR TITLE
fix: remove duplicate paragraph in section 5

### DIFF
--- a/src/sections/section-5.mdx
+++ b/src/sections/section-5.mdx
@@ -44,9 +44,7 @@ Or are you interested in the full data set of this survey to run your own analys
 
 <ContentBlock>
 
-The 2019 Design Systems Survey is just the start! Sign up and receive one to two emails each month with more information on design systems and other web design and development content right to your inbox.
-
-The 2019 Design Systems Survey is just the start. Sign up and receive one to two emails each moth with more information on design systems and other web design and development content right to your inbox.
+The 2019 Design Systems Survey is just the start. Sign up and receive one to two emails each month with more information on design systems and other web design and development content right to your inbox.
 <Form />
 
 </ContentBlock>


### PR DESCRIPTION
This removes the duplicate paragraph at the bottom of the site and fixes a typo.

<img width="896" alt="Screen Shot 2019-09-05 at 5 06 31 PM" src="https://user-images.githubusercontent.com/3081483/64386297-b1a0d700-d006-11e9-997d-28b7cb89b2d8.png">

To validate:
- Run `gatsby develop`
- Go to http://localhost:8000/
- Scroll to Section 5 and make sure that the paragraph is typo free and no longer duplicated.
