### PR TITLE
feat: Add og:title to site metaData

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -41,6 +41,7 @@ const Layout = ({ children }) => (
           <meta property="og:type" content="website" />
           <meta property="og:image" content="/images/ogimage-2019.jpg" />
           <meta property="og:locale" content="en_US" />
+          <meta property="og:title" content={data.site.siteMetadata.title} />
 
           <meta name="twitter:card" content="summary" />
           <meta name="twitter:site" content="@hearsparkbox" />


### PR DESCRIPTION
issue:
- Twitter Cards shared from the site do not render previews or pass
twitter card validation.

fix:
From what I gather, adding a og:title could resolve the error.

Validation instructions:
pull down branch.
run `npm run develop`
inspect `<head>` and observe added `og:title` meta tag added.

I don't think we can fully test that this solution works until it is deployed at a url for which we can utilize https://cards-dev.twitter.com/validator