### PR TITLE
fix: og:image path absolute so twitter can read

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -39,9 +39,10 @@ const Layout = ({ children }) => (
           <meta name="description" content={data.site.siteMetadata.description} />
 
           <meta property="og:type" content="website" />
-          <meta property="og:image" content="/images/ogimage-2019.jpg" />
+          <meta property="og:image" content="https://designsystemssurvey.seesparkbox.com/images/ogimage-2019.jpg" />
           <meta property="og:locale" content="en_US" />
           <meta property="og:title" content={data.site.siteMetadata.title} />
+          <meta property="og:description" content={data.site.siteMetadata.description} />
 
           <meta name="twitter:card" content="summary" />
           <meta name="twitter:site" content="@hearsparkbox" />


### PR DESCRIPTION
[Jira SC 817](https://sparkbox.atlassian.net/browse/SC-817)

From what I could tell, `og:image` tag needs to be an absolute URL in order for twitter to recognize the image.

To validate: Insert [Netfily Preview URL](https://5e7a4885287d41079732e6ea--angry-mirzakhani-365cef.netlify.com/2019/) into https://cards-dev.twitter.com/validator and ensure the image appears

Preview URL: https://5e7a4885287d41079732e6ea--angry-mirzakhani-365cef.netlify.com/2019/

![image](https://user-images.githubusercontent.com/9965014/77460056-fccddc00-6dd6-11ea-8ce4-e44a2c35bb87.png)
