### PR TITLE
2020 Updates

### DIFF
--- a/2018/src/drizzle/patterns/footer/footer.hbs
+++ b/2018/src/drizzle/patterns/footer/footer.hbs
@@ -45,22 +45,6 @@ title: Footer
         </div>
       </div>
     </address>
-    <address class="cmp-footer__address">
-      <p class="cmp-footer__section-heading">
-        <a href="https://www.google.com/maps/place/1+PPG+Place,+Pittsburgh,+PA+15222" class="cmp-footer__link">
-          Steel City
-        </a>
-      </p>
-      <div class="cmp-footer__address-info">
-        <div>One PPG Place</div>
-        <div>Floor 31</div>
-        <div>
-          <span class="locality">Pittsburgh</span>,
-          <abbr class="region cmp-footer__address-abbr" title="Pennsylvania">PA</abbr>
-          <span class="postal-code">15222</span>
-        </div>
-      </div>
-    </address>
   </section>
 
   <section class="cmp-footer__section cmp-footer__section--social">

--- a/2018/src/drizzle/templates/template.hbs
+++ b/2018/src/drizzle/templates/template.hbs
@@ -39,7 +39,7 @@
       height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 
-    <a href="/" class="cmp-latest-link">See the results from the latest <span class="cmp-latest-link__styled">Design Systems Survey</span></a>
+    <a href="/" class="cmp-latest-link">Check out the results from the latest <span class="cmp-latest-link__styled">Design Systems Survey</span></a>
 
     {{#block "body"}}
       {{#block "main"}}

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -36,7 +36,6 @@ const Footer = () => (
           <a className="cmp-footer__contact-link" href="https://seesparkbox.com/work-with-us">/work-with-us</a>
         </div>
       </div>
-      <div className="cmp-footer__flex cmp-footer__contact">
       <div className="cmp-footer__item">
         <h4 className="font-diagram-heading font-diagram-heading--footer">Call Us</h4>
         <div className="cmp-footer__contact-link-container">

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -31,12 +31,16 @@ const Footer = () => (
     </div>
     <div className="cmp-footer__flex cmp-footer__contact">
       <div className="cmp-footer__item">
-        <h4 className="font-diagram-heading font-diagram-heading--footer">Contact</h4>
+        <h4 className="font-diagram-heading font-diagram-heading--footer">Email</h4>
         <div className="cmp-footer__contact-link-container">
           <a className="cmp-footer__contact-link" href="https://seesparkbox.com/work-with-us">/work-with-us</a>
         </div>
+      </div>
+      <div className="cmp-footer__flex cmp-footer__contact">
+      <div className="cmp-footer__item">
+        <h4 className="font-diagram-heading font-diagram-heading--footer">Call Us</h4>
         <div className="cmp-footer__contact-link-container">
-          <a className="cmp-footer__contact-link" href="tel:19374010915" aria-label="Call us 937-401-0915">937 401 0915</a>
+          <a className="cmp-footer__contact-link" href="tel:19374010915" aria-label="937-401-0915">937 401 0915</a>
         </div>
       </div>
       <div className="cmp-footer__item">
@@ -47,16 +51,6 @@ const Footer = () => (
           <span className="cmp-footer__address">Dayton</span>,
           <abbr className="cmp-footer__address util-margin-lft025" title="Ohio">OH</abbr>
           <span className="cmp-footer__address util-margin-lft025">45402</span>
-        </div>
-      </div>
-      <div className="cmp-footer__item">
-        <h4 className="font-diagram-heading font-diagram-heading--footer">Steel City</h4>
-        <p className="cmp-footer__address">One PPG Place</p>
-        <p className="cmp-footer__address">Floor 31</p>
-        <div className="cmp-footer__address">
-          <span className="cmp-footer__address">Pittsburgh</span>,
-          <abbr className="cmp-footer__address util-margin-lft025" title="Pennsylvania">PA</abbr>
-          <span className="cmp-footer__address util-margin-lft025">15222</span>
         </div>
       </div>
     </div>

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -10,7 +10,6 @@ const NotFoundPage = () => (
         <h1 className="cmp-404__title">404 Error</h1>
         <h3 className="cmp-404__description">We can't seem to find the page you're looking for.</h3>
         <p>Were you looking for this year's <a href="https://designsystemssurvey.seesparkbox.com/">Design System Survey results</a>?</p>
-        <p>Or maybe <a href="https://designsystemssurvey.seesparkbox.com/2018">last year's results</a>?</p>
       </section>
     </ContentBlock>
   </Layout>

--- a/src/sections/intro.mdx
+++ b/src/sections/intro.mdx
@@ -1,7 +1,7 @@
 import SpecialLink from "../components/callout-link"
 
 <div className="util-margin-btm4">
-  <SpecialLink href="https://www.surveymonkey.com/r/FPR7KCQ">Fill out the 2020 survey and help us all&nbsp;learn!</SpecialLink>
+  <SpecialLink href="https://designsystemssurvey.seesparkbox.com/">Check out the results from the latest Design Systems Survey</SpecialLink>
 </div>
 
 The 2019 Design Systems Survey is intended to illuminate how design systems are created, used, and maintained. Design systems have the ability to solve real-life problems by establishing consistency in design and code, promoting efficiency when creating products, communicating usage guidance, encouraging reuse instead of rework, increasing the accessibility and usability of digital properties, and so much more.


### PR DESCRIPTION
This PR covers:
- simple copy edits to point to the latest year on both 2018 and 2019 homepages and the 404 page
- removes old industrious address on 2018 and 2019