### PR TITLE
chore: update seesparkbox urls to sparkbox.com

### DIFF
--- a/2018/src/drizzle/patterns/content-sections/intro.hbs
+++ b/2018/src/drizzle/patterns/content-sections/intro.hbs
@@ -6,7 +6,7 @@ order: 10
   <div class="cmp-intro__inner">
 
     <div class="cmp-intro__logo-wrapper">
-      <a href="https://seesparkbox.com">
+      <a href="https://sparkbox.com">
         <img class="cmp-intro__logo" src="/2018/svg/sparkbox-logo.svg" alt="Sparkbox">
       </a>
     </div>

--- a/2018/src/drizzle/patterns/content-sections/next-steps.hbs
+++ b/2018/src/drizzle/patterns/content-sections/next-steps.hbs
@@ -30,7 +30,7 @@ Sign up to stay informed on how you can keep your organization’s design system
 
 <h3 class="obj-unveiler">Get help.</h3>
 
-Learning is at the core of what Sparkbox does. We offer training sessions and standalone workshops on a variety of subjects, including [design systems](https://seesparkbox.com/foundry/design_systems_workshop). If you are interested in helping your team level up on building and maintaining design systems, please <a href="mailto:info@heysparkbox.com?subject=2018%20Design%20Systems%20Survey%20Contact">reach out for more information</a>.
+Learning is at the core of what Sparkbox does. We offer training sessions and standalone workshops on a variety of subjects, including [design systems](https://sparkbox.com/foundry/design_systems_workshop). If you are interested in helping your team level up on building and maintaining design systems, please <a href="mailto:info@heysparkbox.com?subject=2018%20Design%20Systems%20Survey%20Contact">reach out for more information</a>.
 
     {{/markdown}}
 

--- a/2018/src/drizzle/patterns/footer/footer.hbs
+++ b/2018/src/drizzle/patterns/footer/footer.hbs
@@ -6,7 +6,7 @@ title: Footer
   <section class="cmp-footer__section cmp-footer__section--madeby">
     <h3 class="util-visually-hidden">Legal</h3>
 
-    <p class="cmp-footer__sparkbox">Assembled by your<br>friends at <strong><a href="https://seesparkbox.com" class="cmp-footer__link">Sparkbox</a></strong>.
+    <p class="cmp-footer__sparkbox">Assembled by your<br>friends at <strong><a href="https://sparkbox.com" class="cmp-footer__link">Sparkbox</a></strong>.
 
     <p class="cmp-footer__github"><a href="https://github.com/sparkbox/designsystemssurvey" class="cmp-footer__link">See this site on&nbsp;Github</a></p>
 
@@ -18,33 +18,14 @@ title: Footer
   <section class="cmp-footer__section cmp-footer__section--contact cmp-footer__section--double">
     <div class="cmp-footer__contact-group">
       <h3 class="cmp-footer__section-heading">Email</h3>
-      <p class="cmp-footer__contact-info"><a href="https://seesparkbox.com/work-with-us" class="cmp-footer__link">/work-with-us</a></p>
+      <p class="cmp-footer__contact-info"><a href="https://sparkbox.com/contact" class="cmp-footer__link">/contact</a></p>
     </div>
+  </section>
+  <section class="cmp-footer__section cmp-footer__section--double">
     <div class="cmp-footer__contact-group">
       <h3 class="cmp-footer__section-heading">Phone</h3>
       <p class="cmp-footer__contact-info"><a href="tel:+19374010915" class="cmp-footer__link">937 401 0915</a></p>
     </div>
-  </section>
-
-  <section class="cmp-footer__section cmp-footer__section--locations cmp-footer__section--double">
-    <h3 class="util-visually-hidden">Locations</h3>
-
-    <address class="cmp-footer__address">
-      <p class="cmp-footer__section-heading">
-        <a href="https://www.google.com/maps/place/123+Webster+St.,+Dayton,+OH+45402" class="cmp-footer__link">
-          Address
-        </a>
-      </p>
-      <div class="cmp-footer__address-info">
-        <div>123 Webster St.</div>
-        <div>Studio 2</div>
-        <div>
-          <span class="locality">Dayton</span>,
-          <abbr class="region cmp-footer__address-abbr" title="Ohio">OH</abbr>
-          <span class="postal-code">45402</span>
-        </div>
-      </div>
-    </address>
   </section>
 
   <section class="cmp-footer__section cmp-footer__section--social">

--- a/2018/src/drizzle/templates/default.hbs
+++ b/2018/src/drizzle/templates/default.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="drizzle-Layout">
+<html class="drizzle-Layout" lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/components/2019/footer.js
+++ b/src/components/2019/footer.js
@@ -9,15 +9,15 @@ import YouTube from "./icon-youtube"
 const Footer = () => (
   <footer className="obj-layout-max-width cmp-footer">
     <div className="cmp-footer__flex">
-      <a className="cmp-footer__logo-link cmp-footer__item cmp-footer__item--third cmp-footer__order-sm-1" href="https://seesparkbox.com/">
+      <a className="cmp-footer__logo-link cmp-footer__item cmp-footer__item--third cmp-footer__order-sm-1" href="https://sparkbox.com/">
         <svg className="cmp-footer__logo" width="158" height="173" viewBox="0 0 158 173" fill="none">
-          <title>Seesparkbox.com</title>
+          <title>Sparkbox.com</title>
           <path fillRule="evenodd" stroke="#FFF" strokeWidth="2" d="M130.2 125.9c0 6.4-5.2 11.6-11.7 11.6H79.8l34.8-23.3h3.9c6.5 0 11.7 5.2 11.7 11.7zm-91.6 11.6v-23.3H60L46 137.5h-7.5zm0-97h39.6L38.6 66.9V40.5zm79.8 0c6.6 0 11.8 5.2 11.8 11.6 0 6.4-5.2 11.6-11.7 11.6H101.6l13.9-23.2h2.9zM155.7 84H31l78-52-23.7 39.8-.2.6c0 .7.6 1.3 1.3 1.3H118.5c12 0 21.8-9.7 21.8-21.6 0-11-8.3-20-19-21.4l15.9-26.8.2-.7a1.2 1.2 0 0 0-2-1L120.7 12 93.1 30.6H29.8c-.6 0-1.2.6-1.2 1.2V73.7l-27 18c-.3.3-.6.7-.6 1.1 0 .7.6 1.3 1.3 1.3H127l-72 48 21.2-35.7c.2-.3.3-.5.3-.8 0-.6-.6-1.2-1.2-1.2H29.8c-.7 0-1.2.6-1.2 1.2v40.7c0 .7.5 1.2 1.2 1.2h10.4l-13.4 22.7c-.2.2-.2.4-.2.7a1.3 1.3 0 0 0 2 1l36.3-24.4h53.6c12 0 21.8-9.6 21.8-21.5 0-9-5.5-16.6-13.3-19.9l29.3-19.6c.4-.2.7-.7.7-1.1 0-.7-.6-1.3-1.3-1.3z"/>
         </svg>
       </a>
       <div className="cmp-footer__item cmp-footer__item--third cmp-footer__order-sm-2">
         <p className="cmp-footer__details-text">
-          Assembled by your friends at <a href="https://seesparkbox.com/">Sparkbox</a>
+          Assembled by your friends at <a href="https://sparkbox.com/">Sparkbox</a>
         </p>
         <p className="cmp-footer__details-text">
           Check out this site on <a href="https://github.com/sparkbox/designsystemssurvey">Github</a>
@@ -33,23 +33,13 @@ const Footer = () => (
       <div className="cmp-footer__item">
         <h4 className="font-diagram-heading font-diagram-heading--footer">Email</h4>
         <div className="cmp-footer__contact-link-container">
-          <a className="cmp-footer__contact-link" href="https://seesparkbox.com/work-with-us">/work-with-us</a>
+          <a className="cmp-footer__contact-link" href="https://sparkbox.com/contact">/contact</a>
         </div>
       </div>
       <div className="cmp-footer__item">
         <h4 className="font-diagram-heading font-diagram-heading--footer">Phone</h4>
         <div className="cmp-footer__contact-link-container">
           <a className="cmp-footer__contact-link" href="tel:19374010915" aria-label="937-401-0915">937 401 0915</a>
-        </div>
-      </div>
-      <div className="cmp-footer__item">
-        <h4 className="font-diagram-heading font-diagram-heading--footer">Address</h4>
-        <p className="cmp-footer__address">123 Webster St.</p>
-        <p className="cmp-footer__address">Studio 2</p>
-        <div className="cmp-footer__address">
-          <span className="cmp-footer__address">Dayton</span>,
-          <abbr className="cmp-footer__address util-margin-lft025" title="Ohio">OH</abbr>
-          <span className="cmp-footer__address util-margin-lft025">45402</span>
         </div>
       </div>
     </div>

--- a/src/components/2019/hero.js
+++ b/src/components/2019/hero.js
@@ -3,7 +3,7 @@ import React from "react"
 const Hero = () => (
   <div className="cmp-hero">
     <h1 className="cmp-hero__heading">
-      <a className="cmp-hero__logo" href="https://seesparkbox.com">
+      <a className="cmp-hero__logo" href="https://sparkbox.com">
         <img src="/images/logo.svg" alt="Sparkbox" />
       </a>
       <span className="cmp-hero__title">

--- a/src/components/2020/footer.js
+++ b/src/components/2020/footer.js
@@ -6,35 +6,23 @@ const SiteFooter = ({animate}) => (
     <div className={animate ? 'obj-footer cmp-fade-up js-watch' : 'obj-footer'} data-animate="cmp-fade-up--animate">
       <div className="util-text-center">
         <div aria-hidden="true" className="cmp-footer__logo org"><span className="util-visually-hidden">Sparkbox</span></div>
-        <p className="util-font-p util-text-center">Assembled by your friends at <a href="https://seesparkbox.com/" className="util-link url">Sparkbox</a>.</p>
+        <p className="util-font-p util-text-center">Assembled by your friends at <a href="https://sparkbox.com/" className="util-link url">Sparkbox</a>.</p>
       </div>
       <hr className="cmp-hr-blue util-margin-vertical-lg util-width-full" />
       <div className="obj-grid">
-        <div className="obj-grid__full obj-grid__half@md obj-grid__quarter@lg">
+        <div className="obj-grid__full obj-grid__half@md obj-grid__third@lg">
           <h3 className="util-font-h4">Email</h3>
           <p className="util-font-p util-weight-700">
-            <a href="https://seesparkbox.com/work-with-us" className="util-link url">/work-with-us﻿</a>
+            <a href="https://sparkbox.com/contact" className="util-link url">/contact</a>
           </p>
         </div>
-        <div className="obj-grid__full obj-grid__half@md obj-grid__quarter@lg">
+        <div className="obj-grid__full obj-grid__half@md obj-grid__third@lg">
           <h3 className="util-font-h4">Phone</h3>
           <p className="util-font-p util-weight-700">
             <a href="tel:+19374010915﻿" className="util-link tel">937 401 0915﻿</a>
           </p>
         </div>
-        <div className="obj-grid__full obj-grid__half@md obj-grid__quarter@lg">
-          <h3 className="util-font-h4">Mail</h3>
-          <div className="util-font-p adr">
-            <div className="street-address">
-              <div>123 Webster St.</div>
-              <div>Studio 2</div>
-            </div>
-            <div>
-              <span className="locality">Dayton</span>, <span className="region">OH</span> <span className="postal-code">45402</span>
-            </div>
-          </div>
-        </div>
-        <div className="obj-grid__full obj-grid__half@md obj-grid__quarter@lg">
+        <div className="obj-grid__full obj-grid__half@md obj-grid__third@lg">
           <div className="cmp-footer__social-icons">
             <a href="https://twitter.com/hearsparkbox" className="cmp-footer__social-icon cmp-footer__social-icon--twitter url">
               <span className="util-visually-hidden">Twitter</span>

--- a/src/components/2020/footer.js
+++ b/src/components/2020/footer.js
@@ -22,7 +22,7 @@ const SiteFooter = ({animate}) => (
             <a href="tel:+19374010915﻿" className="util-link tel">937 401 0915﻿</a>
           </p>
         </div>
-        <div className="obj-grid__full obj-grid__half@md obj-grid__third@lg">
+        <div className="obj-grid__full obj-grid__half@md obj-grid__third@lg util-justify-end">
           <div className="cmp-footer__social-icons">
             <a href="https://twitter.com/hearsparkbox" className="cmp-footer__social-icon cmp-footer__social-icon--twitter url">
               <span className="util-visually-hidden">Twitter</span>

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -13,11 +13,11 @@ class SEO extends Component {
     };
     this.htmlClassCheck = this.htmlClassCheck.bind(this);
   }
-  
+
   componentDidMount() {
     this.setState({ htmlClass : this.htmlClassCheck() })
   }
-  
+
   htmlClassCheck() {
     let htmlClass = 'safe-focus js';
     if ('IntersectionObserver' in window) {
@@ -27,7 +27,7 @@ class SEO extends Component {
     }
     return htmlClass;
   }
- 
+
   render () {
     return (
       <StaticQuery
@@ -46,21 +46,21 @@ class SEO extends Component {
           `}
         render = { data => (
           <Helmet title={`The ${this.props.year} ${data.site.siteMetadata.titleTemplate}`}>
-            <html className={this.state.htmlClass} />
+            <html className={this.state.htmlClass} lang="en"/>
             <meta name="application-name" content={`${this.props.year} Design Systems Survey`} />
             <meta name="author" content={data.site.siteMetadata.author} />
             <meta name="description" content={ this.props.pageDescription || data.site.siteMetadata.description } />
-      
+
             <meta property="og:description" content={ this.props.pageDescription || data.site.siteMetadata.description } />
             <meta property="og:image" content={`${data.site.siteMetadata.baseUrl}/images/${this.props.image}`} />
             <meta property="og:locale" content={this.props.locale} />
             <meta property="og:title" content={`The ${this.props.year} ${data.site.siteMetadata.titleTemplate}`} />
             <meta property="og:type" content="website" />
             <meta property="og:url" content={`${data.site.siteMetadata.baseUrl}/${this.props.year}`} />
-      
+
             <meta name="twitter:card" content="summary" />
             <meta name="twitter:site" content={data.site.siteMetadata.author} />
-      
+
             <link rel="canonical" href={`${data.site.siteMetadata.baseUrl}/${this.props.year}`} />
             {this.props.fontCSS && <link rel="stylesheet" type="text/css" href={this.props.fontCSS} />}
             <link rel="stylesheet" type="text/css" href={`/css/${this.props.year}.css`} />
@@ -75,7 +75,7 @@ SEO.defaultProps = {
   pageDescription: null,
   image: null,
   locale: 'en_US',
-  fontCSS: null, 
+  fontCSS: null,
   year: null
 }
 

--- a/src/pages/2019.js
+++ b/src/pages/2019.js
@@ -19,7 +19,7 @@ const Page2019 = () => (
     <SEO
       pageDescription="How are design systems for websites and apps changing the way the industry works? Sparkbox conducted a survey and is excited to share findings on the benefits and challenges of this impactful, systemic work."
       image="ogimage-2019.jpg"
-      fontCSS="https:cloud.typography.com/655912/7241412/css/fonts.css"
+      fontCSS="https://cloud.typography.com/655912/7241412/css/fonts.css"
       year="2019"
     />
     <svg width="0" height="0" className="util-visually-hidden">

--- a/src/scss/2020/components/_site-footer.scss
+++ b/src/scss/2020/components/_site-footer.scss
@@ -23,7 +23,7 @@
       --size: 8rem;
     }
   }
-  
+
   &__social-icons {
     display: flex;
     flex-wrap: wrap;
@@ -34,10 +34,6 @@
       grid-template-columns: 3rem 3rem 3rem;
       grid-auto-rows: auto;
       margin-top: space(sm);
-
-      @media (min-width: $bp-lg) {
-        margin-top: 6rem;
-      }
     }
   }
 
@@ -51,7 +47,7 @@
     background-color: color(blue);
     border-radius: 50%;
     transition: background-color 250ms ease-in-out;
-    
+
     @supports (display: grid) {
       margin: 0;
     }

--- a/src/scss/2020/objects/_layout.scss
+++ b/src/scss/2020/objects/_layout.scss
@@ -14,8 +14,8 @@
   margin: 0 auto;
   padding: space(lg) 0;
   width: calc(100% - 2.5rem);
-  max-width: 80rem;
-  
+  max-width: 60rem;
+
   @media (min-width: $bp-md) {
     padding: space(h1) 0;
   }

--- a/src/scss/2020/utilities/_display.scss
+++ b/src/scss/2020/utilities/_display.scss
@@ -52,3 +52,7 @@ $util-flex-values: (
     }
   }
 }
+
+.util-justify-end {
+  justify-items: end;
+}

--- a/src/sections/2019/intro.mdx
+++ b/src/sections/2019/intro.mdx
@@ -9,4 +9,4 @@ The 2019 Design Systems Survey is intended to illuminate how design systems are 
 For the [second year in a row][1], [Sparkbox][2], a web design and development firm, has conducted this survey to learn more about both the challenges and benefits of building and using design systems. By analyzing the reflections of in-house teams who use a design system and agencies who’ve helped organizations build new or maintain existing design systems, we look to inform those who want to build or improve their own.
 
 [1]: https://designsystemssurvey.seesparkbox.com/2018/ "2018 Design System Survey"
-[2]: https://seesparkbox.com/ "Sparkbox Website"
+[2]: https://sparkbox.com/ "Sparkbox Website"

--- a/src/sections/2019/section-5.mdx
+++ b/src/sections/2019/section-5.mdx
@@ -32,79 +32,79 @@ Efficiency suggests speed, and speed can result in time and cost savings. This i
 <LinkList>
   <LinkItem
     title="Your Design System Team Is Part of the&nbsp;Product"
-    href="https://seesparkbox.com/foundry/design_systems_teams_are_part_of_the_product"
+    href="https://sparkbox.com/foundry/design_systems_teams_are_part_of_the_product"
     author="Drew Clemens"
-    authorUrl="https://seesparkbox.com/foundry/author/drew_clemens"
+    authorUrl="https://sparkbox.com/foundry/author/drew_clemens"
   />
 
   <LinkItem
     title="Engaging Subscribers in Your Design System from FullStack&nbsp;NYC"
-    href="https://seesparkbox.com/foundry/making_design_systems_engaging_session_from_fullstack_NYC"
+    href="https://sparkbox.com/foundry/making_design_systems_engaging_session_from_fullstack_NYC"
     author="Catherine Meade"
-    authorUrl="https://seesparkbox.com/foundry/author/catherine_meade"
+    authorUrl="https://sparkbox.com/foundry/author/catherine_meade"
   />
 
   <LinkItem
     title="How to Get Started with a Design&nbsp;System"
-    href="https://seesparkbox.com/foundry/design_system_planning_project_discovery_phase"
+    href="https://sparkbox.com/foundry/design_system_planning_project_discovery_phase"
     author="Emily Gray"
-    authorUrl="https://seesparkbox.com/foundry/author/emily_gray"
+    authorUrl="https://sparkbox.com/foundry/author/emily_gray"
   />
 
   <LinkItem
     title="The Top Design System Tools from Our 2019 Survey and Why “Top” Might Be an&nbsp;Overstatement"
-    href="https://seesparkbox.com/foundry/comparing_design_system_tools"
+    href="https://sparkbox.com/foundry/comparing_design_system_tools"
     author="Julie Young"
-    authorUrl="https://seesparkbox.com/foundry/author/julie_young"
+    authorUrl="https://sparkbox.com/foundry/author/julie_young"
   />
 
   <LinkItem
     title="Rationale for Automated Testing and Continuous Integration for Design Systems"
-    href="https://seesparkbox.com/foundry/automated_testing_for_design_systems"
+    href="https://sparkbox.com/foundry/automated_testing_for_design_systems"
     author="Adam Simpson"
-    authorUrl="https://seesparkbox.com/foundry/author/adam_simpson"
+    authorUrl="https://sparkbox.com/foundry/author/adam_simpson"
   />
 
   <LinkItem
     title="Visual Regression Testing in Design Systems"
-    href="https://seesparkbox.com/foundry/design_system_visual_regression_testing"
+    href="https://sparkbox.com/foundry/design_system_visual_regression_testing"
     author="Patrick Fulton"
-    authorUrl="https://seesparkbox.com/foundry/author/patrick_fulton"
+    authorUrl="https://sparkbox.com/foundry/author/patrick_fulton"
   />
 
   <LinkItem
     title="Accessibility Testing Design Systems"
-    href="https://seesparkbox.com/foundry/design_system_accessibility_testing"
+    href="https://sparkbox.com/foundry/design_system_accessibility_testing"
     author="Rob Tarr"
-    authorUrl="https://seesparkbox.com/foundry/author/rob_tarr"
+    authorUrl="https://sparkbox.com/foundry/author/rob_tarr"
   />
 
   <LinkItem
     title="Testing the Components and Behaviors of Your Design System"
-    href="https://seesparkbox.com/foundry/design_system_component_testing_unit_testing_behavior_testing"
+    href="https://sparkbox.com/foundry/design_system_component_testing_unit_testing_behavior_testing"
     author="Jon Oliver"
-    authorUrl="https://seesparkbox.com/foundry/author/jon_oliver"
+    authorUrl="https://sparkbox.com/foundry/author/jon_oliver"
   />
 
   <LinkItem
     title="What Do We Value Most About Design Systems?"
-    href="https://seesparkbox.com/foundry/design_systems_benefits_consistency_efficiency_prototyping"
+    href="https://sparkbox.com/foundry/design_systems_benefits_consistency_efficiency_prototyping"
     author="Katy Bowman"
-    authorUrl="https://seesparkbox.com/foundry/author/katy_bowman"
+    authorUrl="https://sparkbox.com/foundry/author/katy_bowman"
   />
 
   <LinkItem
     title="Auditing as a First Step to Design Systems Planning"
-    href="https://seesparkbox.com/foundry/design_audit_for_design_system_planning"
+    href="https://sparkbox.com/foundry/design_audit_for_design_system_planning"
     author="Heather Taylor"
-    authorUrl="https://seesparkbox.com/foundry/author/heather_taylor"
+    authorUrl="https://sparkbox.com/foundry/author/heather_taylor"
   />
 
   <LinkItem
     title="Designing for Design Systems"
-    href="https://seesparkbox.com/foundry/designing_for_design_systems"
+    href="https://sparkbox.com/foundry/designing_for_design_systems"
     author="Ethan Muller"
-    authorUrl="https://seesparkbox.com/foundry/author/ethan_muller"
+    authorUrl="https://sparkbox.com/foundry/author/ethan_muller"
   />
 </LinkList>
 
@@ -129,6 +129,6 @@ The 2019 Design Systems Survey is just the start. Sign up and receive one to two
 
 </ContentBlock>
 
-[1]: https://seesparkbox.com "Sparkbox Website Homepage"
-[2]: https://seesparkbox.com/foundry/category/design_systems "Sparbox Website Foundry Page"
-[3]: https://seesparkbox.com/work-with-us "Sparkbox Website Work With Us Page"
+[1]: https://sparkbox.com "Sparkbox Website Homepage"
+[2]: https://sparkbox.com/foundry/category/design_systems "Sparkbox Website Foundry Page"
+[3]: https://sparkbox.com/contact "Sparkbox Website Work With Us Page"

--- a/src/sections/2020/challenges.mdx
+++ b/src/sections/2020/challenges.mdx
@@ -45,13 +45,13 @@ If hindsight is truly 20/20, planning and developing a clear strategy early in a
 
 <div class="cmp-aside">
   <h3 class="cmp-aside__heading">Are you planning a design system?</h3>
-  <p class="cmp-aside__text">Learn how a <a href="https://seesparkbox.com/foundry/design_system_planning_project_discovery_phase">Discovery phase</a> can help you identify key details to make your design system a success. Or learn how to do <a href="https://seesparkbox.com/foundry/design_audit_for_design_system_planning">an audit to decomp your website</a> and identify and organize elements for future use.</p>
+  <p class="cmp-aside__text">Learn how a <a href="https://sparkbox.com/foundry/design_system_planning_project_discovery_phase">Discovery phase</a> can help you identify key details to make your design system a success. Or learn how to do <a href="https://sparkbox.com/foundry/design_audit_for_design_system_planning">an audit to decomp your website</a> and identify and organize elements for future use.</p>
 </div>
 
 ---
 
 ## Managing Changes to the Design System
-  
+
 ### What teams have maintenance processes?
 
 In general, 63% of in-house respondents have a process for maintaining outdated, unused, or faulty components in their design systems. The age of the system impacted the likelihood to report having a maintenance process:
@@ -108,7 +108,7 @@ The likelihood of having a process was also higher for those in-house respondent
     </tbody>
   </table>
 </div>
-  
+
 <div aria-hidden="true" class="cmp-chart-section cmp-chart-section--is-animated js-watch" data-animate="cmp-chart-section--is-animating">
   <div class="cmp-chart-key">
     <div class="cmp-chart-key__item">Yes, we have a process</div>
@@ -123,7 +123,7 @@ The likelihood of having a process was also higher for those in-house respondent
     <div class="cmp-chart-range__value">100%</div>
   </div>
   <div class="cmp-chart" style="--range: 100;">
-    <div class="cmp-chart__group"> 
+    <div class="cmp-chart__group">
       <div class="cmp-chart__title">Not Very Successful Design System</div>
       <div class="cmp-chart__range cmp-chart__range--no-bg">
         <span class="cmp-chart__data" style="--val: 33">
@@ -134,7 +134,7 @@ The likelihood of having a process was also higher for those in-house respondent
         </span>
       </div>
     </div>
-    <div class="cmp-chart__group"> 
+    <div class="cmp-chart__group">
       <div class="cmp-chart__title">Not Successful Design System</div>
       <div class="cmp-chart__range cmp-chart__range--no-bg">
         <span class="cmp-chart__data" style="--val: 50">
@@ -145,7 +145,7 @@ The likelihood of having a process was also higher for those in-house respondent
         </span>
       </div>
     </div>
-    <div class="cmp-chart__group"> 
+    <div class="cmp-chart__group">
       <div class="cmp-chart__title">Neutral Design System</div>
       <div class="cmp-chart__range cmp-chart__range--no-bg">
         <span class="cmp-chart__data" style="--val: 56">
@@ -159,7 +159,7 @@ The likelihood of having a process was also higher for those in-house respondent
         </span>
       </div>
     </div>
-    <div class="cmp-chart__group"> 
+    <div class="cmp-chart__group">
       <div class="cmp-chart__title">Successful Design System</div>
       <div class="cmp-chart__range cmp-chart__range--no-bg">
         <span class="cmp-chart__data" style="--val: 77">
@@ -173,7 +173,7 @@ The likelihood of having a process was also higher for those in-house respondent
         </span>
       </div>
     </div>
-    <div class="cmp-chart__group"> 
+    <div class="cmp-chart__group">
       <div class="cmp-chart__title">Very Successful Design System</div>
       <div class="cmp-chart__range cmp-chart__range--no-bg">
         <span class="cmp-chart__data" style="--val: 100">
@@ -249,7 +249,7 @@ Perhaps recognizing the complexity and importance in maintaining a design system
     <div class="cmp-chart-range__value">50%</div>
   </div>
   <dl class="cmp-chart" style="--range: 50;">
-    <div class="cmp-chart__group"> 
+    <div class="cmp-chart__group">
       <dt class="cmp-chart__title">A single team is responsible for approving changes.</dt>
       <dd class="cmp-chart__range">
         <span class="cmp-chart__data" style="--val: 48">
@@ -311,10 +311,10 @@ Perhaps recognizing the complexity and importance in maintaining a design system
 ### Takeaway: Launching is just the beginning
 
 Planning ahead for design system maintenance and approval responsibilities evidently contributes to the success of a design system.
-  
+
 <div class="cmp-aside">
   <h3 class="cmp-aside__heading">Does your team struggle with maintaining your design system?</h3>
-  <p class="cmp-aside__text">Discover the benefits of <a href="https://seesparkbox.com/foundry/automated_testing_for_design_systems">automated testing in the maintenance process</a> and learn how <a href="https://seesparkbox.com/foundry/design_systems_teams_are_part_of_the_product">your design system team is part of the product</a>.</p>
+  <p class="cmp-aside__text">Discover the benefits of <a href="https://sparkbox.com/foundry/automated_testing_for_design_systems">automated testing in the maintenance process</a> and learn how <a href="https://sparkbox.com/foundry/design_systems_teams_are_part_of_the_product">your design system team is part of the product</a>.</p>
 </div>
 
 ---
@@ -332,7 +332,7 @@ Since our first survey, respondents have reported adoption as a challenge, and t
 In-house respondents were asked an open-ended question about the biggest challenges they have faced in building, using, or maintaining their system. Adoption was the top answer, with 21 of 56 respondents mentioning it. When agency respondents were asked a similar question, the top reason was also adoption, with 8 of the 25 respondents mentioning it.
 
 Respondents also highlighted the impact adoption has on a design system’s success.
-  
+
 </div>
 
 ### If you feel that your organization’s design system was not successful, what were the primary reasons?
@@ -381,7 +381,7 @@ Respondents also highlighted the impact adoption has on a design system’s succ
     <div class="cmp-chart-range__value">60%</div>
   </div>
   <dl class="cmp-chart" style="--range: 60;">
-    <div class="cmp-chart__group"> 
+    <div class="cmp-chart__group">
       <dt class="cmp-chart__title">Staffing difficulties</dt>
       <dd class="cmp-chart__range">
         <span class="cmp-chart__data" style="--val: 53">
@@ -463,6 +463,6 @@ Perhaps recognizing the importance of adoption, just under half of the in-house 
 
   <div class="cmp-aside">
     <h3 class="cmp-aside__heading">Is your team working on adoption? </h3>
-    <p class="cmp-aside__text">Learn how to <a href="https://seesparkbox.com/foundry/versioning_design_systems_components_with_component_scorecards">use scorecards to provide transparency and guidance for subscribers</a> or learn how to <a href="https://seesparkbox.com/foundry/keeping_subscribers_engaged_in_your_design_system">overcome disengagement and maintain subscriber loyalty</a>.</p>
+    <p class="cmp-aside__text">Learn how to <a href="https://sparkbox.com/foundry/versioning_design_systems_components_with_component_scorecards">use scorecards to provide transparency and guidance for subscribers</a> or learn how to <a href="https://sparkbox.com/foundry/keeping_subscribers_engaged_in_your_design_system">overcome disengagement and maintain subscriber loyalty</a>.</p>
   </div>
 </div>

--- a/src/sections/2020/conclusion.mdx
+++ b/src/sections/2020/conclusion.mdx
@@ -9,10 +9,10 @@ These survey results show that creating and maintaining an impactful design syst
 <div class="obj-max-width util-pad-top-lg util-pad-top-h1@md util-pad-top-h2@lg">
 
 ## Learn more about building, using, and maintaining design systems from the experts at Sparkbox.
- 
-<p><a href="https://seesparkbox.com/">Sparkbox</a> has become an expert in design systems and works to continue helping others by creating content about <a href="https://seesparkbox.com/foundry/category/design_systems">design systems</a>.</p>
 
-Are you looking for help building, adjusting, or maintaining your design system? [Reach out to us for more information on how we can help](https://seesparkbox.com/work-with-us)!
+<p><a href="https://sparkbox.com/">Sparkbox</a> has become an expert in design systems and works to continue helping others by creating content about <a href="https://sparkbox.com/foundry/category/design_systems">design systems</a>.</p>
+
+Are you looking for help building, adjusting, or maintaining your design system? [Reach out to us for more information on how we can help](https://sparkbox.com/contact)!
 
 Or are you interested in the full data set of this survey to run your own analysis? [Download the file on Dropbox](https://www.dropbox.com/s/7bjji6e1iogv7ta/2020%C2%A0Design%20Systems%20Survey%20Full%20Results.numbers?dl=0).
 

--- a/src/sections/2020/intro.mdx
+++ b/src/sections/2020/intro.mdx
@@ -2,7 +2,7 @@
   <h1 class="util-visually-hidden">2020 Design Systems Survey</h1>
   <div class="obj-max-width util-pad-vertical-lg util-pad-vertical-h2@md util-pad-vertical-h3@lg">
     <h2 class="cmp-site-header__sbx cmp-fade-left js-watch" data-animate="cmp-fade-left--animate">
-      <a href="https://seesparkbox.com" class="cmp-site-header__sbx-link">
+      <a href="https://sparkbox.com" class="cmp-site-header__sbx-link">
         <span class="util-visually-hidden">From your friends at Sparkbox.</span>
       </a>
     </h2>

--- a/src/sections/2020/newsletter.mdx
+++ b/src/sections/2020/newsletter.mdx
@@ -2,6 +2,6 @@ import NewsletterForm from "../../components/2020/newsletter-form"
 
 <div class="obj-content-width util-pad-bottom-lg util-pad-bottom-h1@md util-pad-bottom-h2@lg">
   <h2 class="util-font-h2 util-text-center">Sign up for our&nbsp;newsletter</h2>
-  <p class="util-font-p util-text-center">Sign up to receive Sparkbox Newsletters in your inbox, which includes a monthly recap of what’s new on <a href="https://seesparkbox.com/foundry">The&nbsp;Foundry</a>.</p>
+  <p class="util-font-p util-text-center">Sign up to receive Sparkbox Newsletters in your inbox, which includes a monthly recap of what’s new on <a href="https://sparkbox.com/foundry">The&nbsp;Foundry</a>.</p>
   <NewsletterForm />
 </div>

--- a/src/sections/2020/respondents.mdx
+++ b/src/sections/2020/respondents.mdx
@@ -2,7 +2,7 @@ import SectionHeader from "../../components/2020/section-header"
 
 <SectionHeader title="The Respondents" name="respondents">
 
-[Sparkbox](https://seesparkbox.com), a web design and development firm, directed this survey for the third year in a row (check out the [2018](https://designsystemssurvey.seesparkbox.com/2018) and [2019](https://designsystemssurvey.seesparkbox.com/2019/) results if you missed them). This year, the survey received 269 responses.
+[Sparkbox](https://sparkbox.com), a web design and development firm, directed this survey for the third year in a row (check out the [2018](https://designsystemssurvey.seesparkbox.com/2018) and [2019](https://designsystemssurvey.seesparkbox.com/2019/) results if you missed them). This year, the survey received 269 responses.
 
 </SectionHeader>
 
@@ -19,11 +19,11 @@ import SectionHeader from "../../components/2020/section-header"
 
 The two respondent types were asked different sets of questions with many overlapping topics. This allowed us to best understand their viewpoints on design systems. Each audience’s expertise brings value to the survey, so we will be acknowledging both types of responses.
 
-This survey was shared across social media, in Slack channels, at web events attended by our team, at [Sparkbox’s UnConference](http://eepurl.com/g2FbOT), with visitors on [The Foundry](https://seesparkbox.com/foundry), and was emailed directly to web professionals.
+This survey was shared across social media, in Slack channels, at web events attended by our team, at [Sparkbox’s UnConference](http://eepurl.com/g2FbOT), with visitors on [The Foundry](https://sparkbox.com/foundry), and was emailed directly to web professionals.
 
 <h3 class="util-font-h3 util-margin-bottom-sm">170 In-House Respondents</h3>
 
-These respondents were made up of: 
+These respondents were made up of:
 - designers (42%)
 - developers (22%)
 - user experience specialists (19%)
@@ -35,7 +35,7 @@ These respondents came from a range of company sizes, from a few team members to
 
 <h3 class="util-font-h3 util-margin-bottom-sm">99 Agency Respondents</h3>
 
-These respondents were made up of: 
+These respondents were made up of:
 - designers (48%)
 - developers (20%)
 - user experience specialists (8%)


### PR DESCRIPTION
This updates all three sites and aims to make three major changes: 

1. Change all references to seesparkbox.com to sparkbox.com 
1. Update any contact page links from the old site to the new site
1. Remove references to 123 Webster St

Also corrected a couple small typos / linter issues. 

Review each change on all sites and test that links work. 