### PR TITLE
DES-48  2021 quote fix

### DIFF
--- a/src/components/2021/quote.js
+++ b/src/components/2021/quote.js
@@ -3,19 +3,20 @@ import PropTypes from "prop-types"
 
 const Quote = (props) => {
   return (
-    <figure className={`cmp-quote cmp-quote--${props.style}`}>
+    <figure className={`cmp-quote cmp-quote--${props.sizeFormat} cmp-quote--deco-${props.decoStyle}`}>
       <blockquote className="cmp-quote__block">
         {props.children}
       </blockquote>
       <figcaption className="cmp-quote__footer">
-        <div className="cmp-type-mono-micro cmp-quote__cite">{props.cite}</div>
+        <div className="cmp-type-mono-micro cmp-quote__cite">&ndash; {props.cite}</div>
       </figcaption>
     </figure>
   )
 }
 
 Quote.defaultProps = {
-  style: 'small'
+  sizeFormat: 'small',
+  decoStyle: 'rust'
 }
 
 Quote.propTypes = {

--- a/src/pages/21-patterns.js
+++ b/src/pages/21-patterns.js
@@ -221,15 +221,18 @@ class Page2021 extends Component {
             </GridCell>
             
             <GridCell spanLG="6">
-              <Quote styleFormat="large" cite="Person Name">
+              <Quote
+                sizeFormat="large"
+                cite="Person Name">
                 <p>Lorem ipsum dolor sit amet <em>consectetur adipiscing</em> elit in senectus quis sed cum proin, ac elementum lacus fames fermentum parturient diam curabitur quisque aptent condimentum.</p>
               </Quote>
             </GridCell>
             
             <GridCell startLG="9">
-              <Quote styleFormat="small"
+              <Quote
+                decoStyle="alt"
                 cite="Person Name">
-                 <p>Lorem ipsum dolor sit amet consectetur adipiscing elit in senectus quis sed cum proin, ac elementum lacus fames fermentum parturient diam curabitur quisque aptent condimentum.</p>
+                 <p><em>Lorem ipsum dolor sit</em> amet consectetur adipiscing elit in senectus quis sed cum proin, ac elementum lacus fames fermentum parturient diam curabitur quisque aptent condimentum.</p>
                 </Quote>
             </GridCell>
           </Grid>

--- a/src/scss/2021/components/_quote.scss
+++ b/src/scss/2021/components/_quote.scss
@@ -15,12 +15,20 @@
     content: '\201C';
     font-family: var(--font-mono);
     color: var(--color-neutral-1);
-    text-shadow: stroke(var(--color-rust));
     position: absolute;
     z-index: z-index(1);
     top: 0;
     left: 0;
     line-height: 1;
+  }
+  
+  &--deco-rust::before {
+    text-shadow: stroke(var(--color-rust));
+  }
+  
+  &--deco-alt::before {
+    text-shadow: stroke(var(--color-neutral-3));
+    opacity: 0.5;
   }
 
   &--large::before {
@@ -38,13 +46,23 @@
     z-index: z-index(2);
     margin: 0;
     padding: 0;
-  }
-  
-  &__text {
     text-shadow: stroke(var(--color-neutral-1));
-    margin: 0;
   }
   
+  // Block quote text assumes paragraph:  
+  p:not([class]) {
+    @include type-body-large;
+    margin: 0;
+    
+    & + p:not([class]) {
+      margin-top: 1em;
+    }
+  }
+  
+  &--large p:not([class]) {
+    @include type-h2;
+  }
+
   &__footer {
     margin-top: 1rem;
   }

--- a/src/scss/2021/tools/_type.scss
+++ b/src/scss/2021/tools/_type.scss
@@ -1,6 +1,7 @@
 @mixin type-hero {
 	font-family: var(--font-mono);
 	font-size: var(--type-size-hero);
+	font-stretch: stretch(normal);
 	font-weight: weight(thin);
 	letter-spacing: -0.03em;
 	line-height: 1;
@@ -16,6 +17,7 @@
 
 @mixin type-h2 {
 	font-family: var(--font-mono);
+	font-stretch: stretch(normal);
 	font-size: var(--type-size-h2);
 	font-weight: weight(semibold);
 	line-height: 1.2;
@@ -24,6 +26,7 @@
 @mixin type-h3 {
 	font-family: var(--font-mono);
 	font-size: var(--type-size-h3);
+	font-stretch: stretch(normal);
 	font-weight: weight(medium);
 	letter-spacing: 0.06em;
 	text-transform: uppercase;
@@ -33,6 +36,7 @@
 @mixin type-body-large {
 	font-family: var(--font-mono);
 	font-size: var(--type-size-body-lg);
+	font-stretch: stretch(normal);
 	font-weight: weight(light);
 	line-height: 1.4;
 }
@@ -40,6 +44,7 @@
 @mixin type-body {
 	font-family: var(--font-sans);
 	font-size: var(--type-size-body-sm);
+	font-stretch: stretch(normal);
 	font-stretch: stretch(extended);
 }
 
@@ -53,5 +58,6 @@
 @mixin type-mono-micro {
 	font-family: var(--font-mono);
 	font-size: var(--type-size-mono-micro);
+	font-stretch: stretch(normal);
 	font-weight: weight(exbold);
 }

--- a/src/sections/2021/section-5.js
+++ b/src/sections/2021/section-5.js
@@ -22,7 +22,7 @@ const Section5 = () => (
     <GridCell start="1" spanLG="4">
       <Figure count="5.1" caption="136">
         <BarChart
-          styleFormat="small"
+          sizeFormat="small"
           headingLevel="h3"
           title="Some teams are thinking about creating new systems"
           keyMap={['In-house']}
@@ -50,17 +50,19 @@ const Section5 = () => (
 
     <GridCell start="1" spanLG="4">
       <Quote
-        styleFormat="small"
-        cite="-Manager, slightly successful design system">
-        <p className="cmp-type-body-large"><em><strong>Different areas in our org are going in their own directions and believe they need their own design systems.</strong></em> One area in particular is moving to a new backend and was given the mandate from business to create an entirely new visual language. They specifically do not wish to use the existing DS team or system to house and integrate their libraries into <em><strong>(politics, really)</strong></em>.</p>
+        decoStyle="alt"
+        sizeFormat="small"
+        cite="Manager, slightly successful design system">
+        <p><em><strong>Different areas in our org are going in their own directions and believe they need their own design systems.</strong></em> One area in particular is moving to a new backend and was given the mandate from business to create an entirely new visual language. They specifically do not wish to use the existing DS team or system to house and integrate their libraries into <em><strong>(politics, really)</strong></em>.</p>
       </Quote>
     </GridCell>
 
     <GridCell start="1" spanLG="4">
       <Quote
-        styleFormat="small"
-        cite="-Manager, very successful design system">
-        <p className="cmp-type-body-large"><em><strong>Several [lines of business]</strong></em> have spun up new design systems.</p>
+        decoStyle="alt"
+        sizeFormat="small"
+        cite="Manager, very successful design system">
+        <p><em><strong>Several [lines of business]</strong></em> have spun up new design systems.</p>
       </Quote>
     </GridCell>
 
@@ -70,24 +72,24 @@ const Section5 = () => (
 
     <GridCell start="1" spanLG="4">
       <Quote
-        styleFormat="small"
-        cite="-Manager, slightly successful design system">
-        <p className="cmp-type-body-large">To increase adoption as we <em><strong>move towards a common tech stack.</strong></em></p>
+        sizeFormat="small"
+        cite="Manager, slightly successful design system">
+        <p>To increase adoption as we <em><strong>move towards a common tech stack.</strong></em></p>
       </Quote>
     </GridCell>
 
     <GridCell start="1" spanLG="4">
       <Quote
-        styleFormat="small"
-        cite="-Owner, successful design system">
-        <p className="cmp-type-body-large">We've created <em><strong>a lot of technical debt</strong></em> on our way and learned from our mistakes. We're building a new and well documented design system from our existing components... and <em><strong>moving from a very restricted design system to a more flexible system.</strong></em></p>
+        sizeFormat="small"
+        cite="Owner, successful design system">
+        <p>We've created <em><strong>a lot of technical debt</strong></em> on our way and learned from our mistakes. We're building a new and well documented design system from our existing components... and <em><strong>moving from a very restricted design system to a more flexible system.</strong></em></p>
       </Quote>
     </GridCell>
 
     <GridCell start="1" spanLG="4">
       <Figure count="5.2" caption="136">
         <BarChart
-          styleFormat="small"
+          sizeFormat="small"
           headingLevel="h3"
           title="Many teams already have more than one system"
           keyMap={['In-house']}
@@ -108,25 +110,25 @@ const Section5 = () => (
 
     <GridCell start="1" spanLG="4">
       <Quote
-        styleFormat="small"
-        cite="-Manager, successful design system">
-        <p className="cmp-type-body-large">There are different divisions of the company that <em><strong>serve different customers and personas</strong></em>. These teams spun up their own design system.</p>
+        sizeFormat="small"
+        cite="Manager, successful design system">
+        <p>There are different divisions of the company that <em><strong>serve different customers and personas</strong></em>. These teams spun up their own design system.</p>
       </Quote>
     </GridCell>
 
     <GridCell start="1" spanLG="4">
       <Quote
-        styleFormat="small"
-        cite="-Manager, successful design system">
-        <p className="cmp-type-body-large">Our company is large and has multiple group companies that operate almost like their own entities. <em><strong>It's typical for group companies to have one or more systems associated with notably different products</strong></em>.</p>
+        sizeFormat="small"
+        cite="Manager, successful design system">
+        <p>Our company is large and has multiple group companies that operate almost like their own entities. <em><strong>It's typical for group companies to have one or more systems associated with notably different products</strong></em>.</p>
       </Quote>
     </GridCell>
 
     <GridCell start="1" spanLG="4">
       <Quote
-        styleFormat="small"
-        cite="-Individual contributor, slightly successful design system">
-        <p className="cmp-type-body-large">Some brands started mini or micro DSs <em><strong>to bypass central DS police and also have more control</strong></em> over smaller changes or style changes.</p>
+        sizeFormat="small"
+        cite="Individual contributor, slightly successful design system">
+        <p>Some brands started mini or micro DSs <em><strong>to bypass central DS police and also have more control</strong></em> over smaller changes or style changes.</p>
       </Quote>
     </GridCell>
 


### PR DESCRIPTION
This fixes some issues that cropped up after making some changes to the `<Quote />` React component.

The first addresses the missing, and necessary, stroke from the content:

<img width="590" alt="image" src="https://user-images.githubusercontent.com/1128391/123425017-90b8c580-d58f-11eb-9d8d-0cc9f6383e47.png">

The second addresses the type formatting. The component assumes a generic `<p>` element, but will not override specific classes added to it. However, the component accepts a an attribute called `sizeFormat` which can be set to `small` or `large` and will adjust the default style of the `<p>` element accordingly:
<img width="861" alt="image" src="https://user-images.githubusercontent.com/1128391/123425136-bfcf3700-d58f-11eb-8f82-5ba38641a971.png">

Lastly, when a quote starts with a `<em>` the rust color of the text and the quote decoration clash. To provide an alternative, there is a new attribute called `decoStyle`, which can be set to `alt` which will change the stroke on the left double quote to Neutral 03 at 50% opacity:
The first addresses the missing, and necessary, stroke:
<img width="584" alt="image" src="https://user-images.githubusercontent.com/1128391/123424967-85659a00-d58f-11eb-9db1-368d33a9c458.png">

I addressed the quotes in Section 5 and the 21 Patterns page.