### PR TITLE
DES-50 & DES-51: Add PieChart styles to account for edge cases

### DIFF
--- a/src/pages/21-patterns.js
+++ b/src/pages/21-patterns.js
@@ -74,9 +74,7 @@ class Page2021 extends Component {
                   dataPoints={[
                     ['Individual contributor (developer, designer, etc.)', 64],
                     ['Manager', 24],
-                    ['Executive', 4],
-                    ['Owner', 4],
-                    ['Freelancer or independent consultant', 4]
+                    ['Executive', 4]
                   ]}
                 />
               </Figure>

--- a/src/scss/2021/components/_pie-chart.scss
+++ b/src/scss/2021/components/_pie-chart.scss
@@ -71,6 +71,13 @@
   }
 
   &__diagram {
+    // Default Properties:
+    --object-1: 0;
+    --object-2: 0;
+    --object-3: 0;
+    --object-4: 0;
+    --object-5: 0;
+    
     position: relative;
     width: 100%;
     border-radius: 50%;
@@ -102,6 +109,12 @@
       left: calc(50% - 1px);
       transform-origin: bottom center;
       box-shadow: inset 0 0 0 1px var(--color-neutral-3), 0 0 0 0.5px var(--color-neutral-3);
+    }
+    
+    &.util-fill-style-2::after,
+    &.util-fill-style-3::before {
+      // The diagonal fill needs just a bit more border
+      box-shadow: inset 0 0 0 1px var(--color-neutral-3), 0 0 0 1.5px var(--color-neutral-3);
     }
 
     &--object-1 {


### PR DESCRIPTION
Both of these issues were CSS related.

## DES-50: Missing border between slices  3 and 5

I can’t say 100% what is causing this visual issue, but it seem like the diagonal rendering was causing visual issues with the rendering of the border. To fix this I added in a case that when the diagonal is used, to add a bit more to the box-shadow size to account for this issue.

## DES-51: Supporting less than 5 data points

This is a result of missing default CSS Custom Property values. All the props for the slice size, represented with `--slice-X` should start off with a value of `0`. That has been added to the CSS to correct this issue.

See the /21-patterns page components for reference.