### PR TITLE
DES-49: Figure text wrap bug

### DIFF
--- a/src/scss/2021/components/_figure.scss
+++ b/src/scss/2021/components/_figure.scss
@@ -2,17 +2,20 @@
   margin: 0;
   padding: 0;
   position: relative;
-  
+
   &__caption {
     display: flex;
     flex-direction: row-reverse;
+    margin-top: 0.5rem;
     text-align: right;
-    color: color.mix(color(neutral-3), color(neutral-1), 50%);
+    color: color.mix(color(neutral-3), color(neutral-1), 62%);
     @include type-mono-micro;
+    font-weight: weight(bold);
   }
-  
+
   &__count {
-    margin-left: 2rem;
+    flex-shrink: 0;
+    margin-left: 1rem;
     display: inline-block;
     color: var(--color-neutral-3);
   }

--- a/src/scss/2021/tools/_type.scss
+++ b/src/scss/2021/tools/_type.scss
@@ -58,6 +58,7 @@
 @mixin type-mono-micro {
 	font-family: var(--font-mono);
 	font-size: var(--type-size-mono-micro);
+  line-height: 1.2;
 	font-stretch: stretch(normal);
 	font-weight: weight(exbold);
 }

--- a/src/sections/2021/section-1.js
+++ b/src/sections/2021/section-1.js
@@ -38,7 +38,7 @@ const Section1 = () => (
       </Figure>
     </GridCell>
 
-    <GridCell start="2" span="3" startMD="6" spanMD="3" startLG="9" spanLG="4" className="util-margin-bottom-1xl util-margin-bottom-none@md util-margin-top-3xl@md">
+    <GridCell start="2" span="3" startMD="6" spanMD="3" startLG="9" spanLG="4" className="util-margin-bottom-1xl util-margin-top-20vh@md">
       <Figure count="1.2" caption="Responses: In-house: 217; Agency: 159">
         <h2 class="cmp-type-h3">What is your primary discipline?</h2>
 
@@ -78,7 +78,7 @@ const Section1 = () => (
     </GridCell>
 
     <GridCell spanLG="6" className="util-margin-bottom-1xl util-margin-bottom-1xl@md">
-      <Figure count="1.3" caption="Responses: In-house: 217; Agency: 159">
+      <Figure count="1.3" caption="Responses: In-house: 217; Agency:&nbsp;159">
         <BarChart
           headingLevel="h3"
           startStyle="alt"
@@ -97,7 +97,7 @@ const Section1 = () => (
     </GridCell>
 
     <GridCell start="2" startMD="6" startLG="9" className="util-margin-bottom-1xl util-margin-top-20vh@md">
-      <Figure count="1.4" caption="Responses: In-house: 217; Agency: 157">
+      <Figure count="1.4" caption="Responses: In-house: 217; Agency:&nbsp;157">
         <BarChart
           headingLevel="h3"
           startStyle="alt"

--- a/src/sections/2021/section-2.js
+++ b/src/sections/2021/section-2.js
@@ -63,9 +63,11 @@ const Section2 = () => (
       </GridCell>
 
       <GridCell span="4" spanMD="6" spanLG="6" className="util-margin-bottom-1xl">
-        <Figure count="2.3" caption="171 Responses | Respondents were asked to select all that apply from a list of 19 items with an option to enter other answers.">
+        <Figure count="2.3" caption="171 Responses | Respondents were asked to select all that apply from a list of 19 items with an option to enter other&nbsp;answers.">
+
           <h2 class="cmp-type-h3">Design systems have similar elements</h2>
           <p>"What does your design system <em>contain</em>?"</p>
+
           <ScoreRow>
             <ScoreCardLarge border={false}>
               <h4>Color system</h4>

--- a/src/sections/2021/section-3.js
+++ b/src/sections/2021/section-3.js
@@ -24,7 +24,7 @@ const Section3 = () => (
     </GridCell>
 
     <GridCell span="3" spanLG="4" className="util-margin-bottom-1xl">
-      <Figure count="3.1" caption="Responses: 154 | Respondents were asked to select all that apply.">
+      <Figure count="3.1" caption="Responses: 154 | Respondents were asked to select all that&nbsp;apply.">
         <BarChart
           headingLevel="h3"
           title="Priorities"
@@ -50,7 +50,7 @@ const Section3 = () => (
     </GridCell>
 
     <GridCell start="2" span="3" startMD="6" startLG="7" spanLG="4" className="util-margin-bottom-1xl">
-    <Figure count="3.2" caption="Responses: 158 | Respondents were asked to select all that apply.">
+    <Figure count="3.2" caption="Responses: 158 | Respondents were asked to select all that&nbsp;apply.">
       <BarChart
         headingLevel="h3"
         title="Challenges"
@@ -251,7 +251,7 @@ const Section3 = () => (
     </GridCell>
 
     <GridCell startLG="3" className="util-margin-bottom-1xl util-margin-bottom-2xl@md">
-      <Figure count="3.8" caption="Responses: 135 | Answers were on a scale of 1 to 5.">
+      <Figure count="3.8" caption="Responses: 135 | Answers were on a scale of 1 to&nbsp;5.">
         <StackedChart
           headingLevel="h3"
           title={<>More frequent contribution by users is linked to success</>}
@@ -280,7 +280,7 @@ const Section3 = () => (
     </GridCell>
 
     <GridCell span="3" spanMD="5" spanLG="6" className="util-margin-bottom-1xl util-margin-bottom-3xl@md">
-      <Figure count="3.9" caption="Responses: 136 | Answers were on a scale of 1 to 5.">
+      <Figure count="3.9" caption="Responses: 136 | Answers were on a scale of 1 to&nbsp;5.">
         <BarChart
           headingLevel="h3"
           title="But contribution is low"
@@ -307,7 +307,7 @@ const Section3 = () => (
       <Figure
         className="util-margin-bottom-md util-margin-bottom-1xl@md"
         count="3.10"
-        caption="Respondents: 136 | Answers were on a scale of 1 to 5."
+        caption="Respondents: 136 | Answers were on a scale of 1 to&nbps;5."
       >
         <StackedChart
           headingLevel="h3"
@@ -336,7 +336,7 @@ const Section3 = () => (
       <Figure
         className="util-margin-bottom-md util-margin-bottom-1xl@md util-margin-top-2xl@md"
         count="3.11"
-        caption="Respondents: 135 | Answers were on a scale of 1 to 5."
+        caption="Respondents: 135 | Answers were on a scale of 1 to&nbsp;5."
       >
         <StackedChart
           headingLevel="h3"
@@ -364,7 +364,7 @@ const Section3 = () => (
     </GridCell>
 
     <GridCell start="2" startMD="1" spanMD="5" spanLG="6" className="util-margin-bottom-1xl">
-      <Figure count="3.12" caption="Respondents: 136 | Answers were on a scale of 1 to 5.">
+      <Figure count="3.12" caption="Respondents: 136 | Answers were on a scale of 1 to&nbsp;5.">
         <BarChart
           headingLevel="h3"
           title="But most systems don’t have a well-defined process"

--- a/src/sections/2021/section-4.js
+++ b/src/sections/2021/section-4.js
@@ -110,7 +110,7 @@ const Section4 = () => (
     </GridCell>
 
     <GridCell startMD="2" spanMD="6" startLG="3" className="util-margin-bottom-1xl">
-      <Figure count="4.4" caption="38 Responses | Respondents were asked to select all that apply.">
+      <Figure count="4.4" caption="38 Responses | Respondents were asked to select all that&nbsp;apply.">
         <BarChart
           headingLevel="h3"
           styleFormat="small"

--- a/src/sections/2021/section-5.js
+++ b/src/sections/2021/section-5.js
@@ -20,7 +20,7 @@ const Section5 = () => (
     </GridCell>
 
     <GridCell startLG="3" className="util-margin-bottom-1xl util-margin-bottom-2xl@md">
-      <Figure count="5.1" caption="136">
+      <Figure count="5.1" caption="136 Responses">
         <BarChart
           sizeFormat="small"
           headingLevel="h3"
@@ -84,7 +84,7 @@ const Section5 = () => (
     </GridCell>
 
     <GridCell startMD="2" startLG="3" className="util-margin-bottom-1xl">
-      <Figure count="5.2" caption="136">
+      <Figure count="5.2" caption="136 Responses">
         <BarChart
           sizeFormat="small"
           headingLevel="h3"


### PR DESCRIPTION
Addresses a bug where the figure caption number would wrap to two lines if the text was long, causing "fig" to be on one line and the number (like "3.2") to be on the next line.

This also addresses a few other bugs I found around figure captions:

- Change the color of figure caption text to pass A11y guidelines for color contrast.
- Add space between a chart and the caption.
- Add missing labels for "responses" numbers.
- Add non-breaking spaces to long captions to minimize awkward line breaks.