### PR TITLE
DES-46:  Modifier to swap the figure number and caption

### DIFF
--- a/src/components/2021/figure.js
+++ b/src/components/2021/figure.js
@@ -3,13 +3,14 @@ import {PropTypes} from "prop-types"
 
 const Figure = (props) => {
   let customClasses = (props.className != null) ? ` ${props.className}` : ''
+  let directionClass = ` cmp-figure__caption--${props.direction}`
 
   return (
     <figure className={`cmp-figure${customClasses}`}>
       {props.children}
-      <figcaption className="cmp-figure__caption">
+      <figcaption className={`cmp-figure__caption${directionClass}`}>
         <span className="cmp-figure__count">
-          <abbr title="Figure">Fig</abbr> {props.count}
+          <abbr title="Figure">Fig</abbr>&nbsp;{props.count}
         </span>
         <span>{props.caption}</span>
       </figcaption>
@@ -21,6 +22,10 @@ Figure.propTypes = {
   children: PropTypes.string.isRequired,
   count: PropTypes.number.isRequired,
   caption: PropTypes.string
+}
+
+Figure.defaultProps = {
+  direction: "right"
 }
 
 export default Figure

--- a/src/scss/2021/components/_figure.scss
+++ b/src/scss/2021/components/_figure.scss
@@ -5,12 +5,19 @@
 
   &__caption {
     display: flex;
-    flex-direction: row-reverse;
     margin-top: 0.5rem;
     text-align: right;
     color: color.mix(color(neutral-3), color(neutral-1), 62%);
     @include type-mono-micro;
     font-weight: weight(bold);
+
+    &--right {
+      flex-direction: row-reverse;
+    }
+
+    &--left {
+      flex-direction: row;
+    }
   }
 
   &__count {
@@ -18,5 +25,10 @@
     margin-left: 1rem;
     display: inline-block;
     color: var(--color-neutral-3);
+  }
+
+  &__caption--left &__count {
+    margin-left: 0;
+    margin-right: 1rem;
   }
 }


### PR DESCRIPTION
#### Description
- Modifier classes `--left` & `--right` to specify the `direction` of the caption. 
- `direction` has a default of `--right`


`cmp-figure__caption--right`

<img width="367" alt="Screen Shot 2021-06-30 at 9 42 13 AM" src="https://user-images.githubusercontent.com/24901036/123970799-74e66280-d987-11eb-8abd-99308ec612d1.png">

`cmp-figure__caption--left`
<img width="366" alt="Screen Shot 2021-06-30 at 9 43 05 AM" src="https://user-images.githubusercontent.com/24901036/123970925-93e4f480-d987-11eb-95ad-f7bae5de9a01.png">
