### PR TITLE
DES-35:  Accessibility Tables

### DIFF
--- a/src/components/2021/bar-chart-table.js
+++ b/src/components/2021/bar-chart-table.js
@@ -1,0 +1,70 @@
+import React from "react"
+
+const BarChartTable = (props) => {
+  let tableRows = []
+  
+  // Creates single table cell values
+  let cellIterator = (...value) => {
+    let results = []
+    for (let i = 0; i < (value.length + 1); i++) {
+      let result = value[0][i]
+      if (result) {
+        results.push (
+          <td>
+            {result}%
+          </td>
+        );
+      }
+    }
+
+    return (
+      <>{results}</>
+    )
+  }
+
+  // Defines the contents of `<tbody>`
+  for (let i = 0; i < props.dataPoints.length; i++) {
+    tableRows.push(
+      <tr>
+        <th>{props.dataPoints[i][0]}</th>
+        {cellIterator(props.dataPoints[i][1])}
+      </tr>
+    )
+  }
+  
+  // Defines the contents of `<thead>`
+  let tableHead = () => {
+    let results = []
+
+    if (props.keyMap) {
+      for (let i = 0; i < props.keyMap.length; i++) {
+        results.push(
+          <th>
+            {props.keyMap[i]}
+          </th>
+        );
+      }
+
+      return (
+        <thead>
+          <tr>
+            <th>&nbsp;</th>
+            {results}
+          </tr>
+        </thead>
+      )
+    }
+  }
+
+  return (
+    <table className="util-visually-hidden">
+      <caption>{props.title}</caption>
+      {tableHead()}
+      <tbody>
+        {tableRows}
+      </tbody>
+    </table>
+  )
+}
+
+export default BarChartTable

--- a/src/components/2021/bar-chart.js
+++ b/src/components/2021/bar-chart.js
@@ -69,13 +69,13 @@ const BarChart = (props) => {
 
   return (
     <>
-      <div aria-hidden="true" className={`cmp-bar-chart cmp-bar-chart--${props.styleFormat}`}>
+      <div className={`cmp-bar-chart cmp-bar-chart--${props.styleFormat}`}>
         <Tag className="cmp-type-h3">{props.title}</Tag>
         {props.children}
-        <div className="cmp-bar-chart__keys">
+        <div aria-hidden="true" className="cmp-bar-chart__keys">
           {keysMap}
         </div>
-        <div className="cmp-bar-chart__diagram">
+        <div aria-hidden="true" className="cmp-bar-chart__diagram">
           {dataBars}
         </div>
       </div>

--- a/src/components/2021/bar-chart.js
+++ b/src/components/2021/bar-chart.js
@@ -1,5 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
+import BarChartTable from "./bar-chart-table"
 
 const BarChart = (props) => {
   const Tag = props.headingLevel
@@ -67,16 +68,19 @@ const BarChart = (props) => {
   }
 
   return (
-    <div className={`cmp-bar-chart cmp-bar-chart--${props.styleFormat}`}>
-      <Tag className="cmp-type-h3">{props.title}</Tag>
-      {props.children}
-      <div className="cmp-bar-chart__keys">
-        {keysMap}
+    <>
+      <div aria-hidden="true" className={`cmp-bar-chart cmp-bar-chart--${props.styleFormat}`}>
+        <Tag className="cmp-type-h3">{props.title}</Tag>
+        {props.children}
+        <div className="cmp-bar-chart__keys">
+          {keysMap}
+        </div>
+        <div className="cmp-bar-chart__diagram">
+          {dataBars}
+        </div>
       </div>
-      <div className="cmp-bar-chart__diagram">
-        {dataBars}
-      </div>
-    </div>
+      <BarChartTable { ...props } />
+    </>
   )
 }
 

--- a/src/components/2021/stacked-chart-table.js
+++ b/src/components/2021/stacked-chart-table.js
@@ -1,0 +1,72 @@
+import React from "react"
+
+const StackedChartTable = (props) => {
+  let tableRows = []
+  
+  // Creates single table cell values
+  let cellIterator = (value) => {
+    let results = []
+    for (let i = 0; i < value.length; i++) {
+      if (value[i] > 0) {
+        let result = value[i]
+        if (result) {
+          results.push (
+            <td>
+              {result}%
+            </td>
+          );
+        }
+      }
+    }
+
+    return (
+      <>{results}</>
+    )
+  }
+
+  // Defines the contents of `<tbody>`
+  for (let i = 0; i < props.dataPoints.length; i++) {
+    tableRows.push(
+      <tr>
+        <th>{props.dataPoints[i][0]}</th>
+        {cellIterator(props.dataPoints[i][1])}
+      </tr>
+    )
+  }
+  
+  // Defines the contents of `<thead>`
+  let tableHead = () => {
+    let results = []
+
+    if (props.keyMap) {
+      for (let i = 0; i < props.keyMap.length; i++) {
+        results.push(
+          <th>
+            {props.keyMap[i]}
+          </th>
+        );
+      }
+
+      return (
+        <thead>
+          <tr>
+            <th>&nbsp;</th>
+            {results}
+          </tr>
+        </thead>
+      )
+    }
+  }
+
+  return (
+    <table className="util-visually-hidden">
+      <caption>{props.title}</caption>
+      {tableHead()}
+      <tbody>
+        {tableRows}
+      </tbody>
+    </table>
+  )
+}
+
+export default StackedChartTable

--- a/src/components/2021/stacked-chart.js
+++ b/src/components/2021/stacked-chart.js
@@ -1,5 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
+import StackedChartTable from "./stacked-chart-table"
 
 const StackedChart = (props) => {
   const Tag = props.headingLevel
@@ -58,16 +59,20 @@ const StackedChart = (props) => {
   }
 
   return (
-    <div className={`cmp-stacked-chart cmp-stacked-chart--${props.styleFormat}`}>
-      <Tag className="cmp-type-h3">{props.title}</Tag>
-      {props.children}
-      <div className="cmp-stacked-chart__keys">
-        {keysMap}
+    <>
+      <div className={`cmp-stacked-chart cmp-stacked-chart--${props.styleFormat}`}>
+        <Tag className="cmp-type-h3">{props.title}</Tag>
+        {props.children}
+        <div aria-hidden="true" className="cmp-stacked-chart__keys">
+          {keysMap}
+        </div>
+        <div aria-hidden="true" className="cmp-stacked-chart__diagram">
+          {dataBars}
+        </div>
       </div>
-      <div className="cmp-stacked-chart__diagram">
-        {dataBars}
-      </div>
-    </div>
+
+      <StackedChartTable { ...props } />
+    </>
   )
 }
 


### PR DESCRIPTION
This work adds a visually hidden table of the bar and stacked bar charts for an improved screen reader experience.
The tables are not visible, so verifying them will need to be done by viewing the source or disabling the styles.

Additionally, this applies an `aria-hidden` to elements of the bar and stacked that the table is meant to replace for screen readers.