### PR TITLE
DES-38: Render HTML in chart data

### DIFF
--- a/src/components/2021/bar-chart-table.js
+++ b/src/components/2021/bar-chart-table.js
@@ -26,7 +26,9 @@ const BarChartTable = (props) => {
   for (let i = 0; i < props.dataPoints.length; i++) {
     tableRows.push(
       <tr>
-        <th>{props.dataPoints[i][0]}</th>
+        <th>
+          <span dangerouslySetInnerHTML={{__html:props.dataPoints[i][0]}} />
+        </th>
         {cellIterator(props.dataPoints[i][1])}
       </tr>
     )
@@ -40,7 +42,7 @@ const BarChartTable = (props) => {
       for (let i = 0; i < props.keyMap.length; i++) {
         results.push(
           <th>
-            {props.keyMap[i]}
+            <span dangerouslySetInnerHTML={{__html:props.keyMap[i]}} />
           </th>
         );
       }

--- a/src/components/2021/bar-chart.js
+++ b/src/components/2021/bar-chart.js
@@ -20,9 +20,7 @@ const BarChart = (props) => {
       keysMap.push(
         <div className="cmp-bar-chart__key">
           <span className={`cmp-bar-chart__key-marker util-fill-style-${keyStyle}`} />
-          <span className="cmp-bar-chart__key-name">
-            {props.keyMap[i]}
-          </span>
+          <span className="cmp-bar-chart__key-name"  dangerouslySetInnerHTML={{__html:props.keyMap[i]}} />
         </div>
       );
     }

--- a/src/components/2021/stacked-chart-table.js
+++ b/src/components/2021/stacked-chart-table.js
@@ -28,7 +28,9 @@ const StackedChartTable = (props) => {
   for (let i = 0; i < props.dataPoints.length; i++) {
     tableRows.push(
       <tr>
-        <th>{props.dataPoints[i][0]}</th>
+        <th>
+          <span dangerouslySetInnerHTML={{__html:props.dataPoints[i][0]}} />
+        </th>
         {cellIterator(props.dataPoints[i][1])}
       </tr>
     )
@@ -42,7 +44,7 @@ const StackedChartTable = (props) => {
       for (let i = 0; i < props.keyMap.length; i++) {
         results.push(
           <th>
-            {props.keyMap[i]}
+            <span dangerouslySetInnerHTML={{__html:props.keyMap[i]}} />
           </th>
         );
       }

--- a/src/components/2021/stacked-chart.js
+++ b/src/components/2021/stacked-chart.js
@@ -14,9 +14,7 @@ const StackedChart = (props) => {
     keysMap.push(
       <div className="cmp-stacked-chart__key">
         <span className={`cmp-stacked-chart__key-marker util-fill-style-${keyStyle}`} />
-        <span className="cmp-stacked-chart__key-name">
-          {props.keyMap[i]}
-        </span>
+        <span className="cmp-stacked-chart__key-name"  dangerouslySetInnerHTML={{__html:props.keyMap[i]}} />
       </div>
     );
   }


### PR DESCRIPTION
Applies React’s `dangerouslySetInnerHTML` to render the HTML properly