### PR TITLE
DES-61:  heading one markup

### DIFF
--- a/src/components/2021/intro.js
+++ b/src/components/2021/intro.js
@@ -6,13 +6,16 @@ import ArtElement from "../../components/2021/art-element"
 
 const SiteIntro = (props) => {
   return (
-    <div className="cmp-intro" id="top">
-      <div className="cmp-intro__text cmp-intro__text--year">2021</div>
-      <div className="cmp-intro__title-container">
-        <div className="cmp-intro__text">Design</div>
-        <div className="cmp-intro__text">Systems</div>
-        <div className="cmp-intro__text">Survey</div>
-        <ArtElement isHero="true" />
+    <header className="cmp-intro" id="top">
+      <h1 className="util-visually-hidden">The 2021 Design Systems Survey by Sparkbox</h1>
+      <div aria-hidden="true">
+        <div className="cmp-intro__text cmp-intro__text--year">2021</div>
+        <div className="cmp-intro__title-container">
+          <div className="cmp-intro__text">Design</div>
+          <div className="cmp-intro__text">Systems</div>
+          <div className="cmp-intro__text">Survey</div>
+          <ArtElement isHero="true" />
+        </div>
       </div>
       {props.children}
       <div aria-hidden="true" className="cmp-intro__arrow-positioner">
@@ -24,7 +27,7 @@ const SiteIntro = (props) => {
           </GridCell>
         </Grid>
       </div>
-    </div>
+    </header>
   )
 }
 


### PR DESCRIPTION
- Changes the `cmp-intro` `div`  to a `header` element
- Adds a `div` around the two elements containing the title “2021 Design Systems Survey” with an `aria-hidden="true"` 
- Adds a visibly hidden `h1` element with the text “The 2021 Design Systems Survey by Sparkbox”