### PR TITLE
DES-73: Dark mode colors

### DIFF
--- a/src/pages/2021.js
+++ b/src/pages/2021.js
@@ -94,7 +94,7 @@ class Page2021 extends Component {
             <Grid>
               <GridCell spanLG="5">
                 <svg style={{maxWidth: 4 + 'rem'}} viewBox="0 0 64 64">
-                  <path style={{stroke: 'var(--color-neutral-1)'}} d="M.5 9.643h63v38.619H.5V9.642z" stroke="#FFFEFA"/>
+                  <path style={{stroke: 'var(--color-neutral-1)', fill: 'var(--color-neutral-3)'}} d="M.5 9.643h63v38.619H.5V9.642z" stroke="#FFFEFA"/>
                   <path style={{fill: 'var(--color-neutral-1)'}} d="M0 9.143h64L32 26.666 0 9.143z" fill="#FFFEFA"/>
                 </svg>
 

--- a/src/scss/2021/components/_checkbox.scss
+++ b/src/scss/2021/components/_checkbox.scss
@@ -10,8 +10,8 @@
     width: 1.5rem;
     height: 1.5rem;
     border-radius: 0;
-    border: 1px solid color(neutral-1);
-    background: color(neutral-3);
+    border: 1px solid var(--color-neutral-1);
+    background: var(--color-neutral-3);
     cursor: pointer;
     transition: all var(--time-sm) var(--timing-snap);
 
@@ -22,7 +22,7 @@
       right: 0;
       bottom: 0;
       left: 0;
-      background: color(neutral-1);
+      background: var(--color-neutral-1);
       transition: all var(--time-sm) var(--timing-snap);
       transform-origin: top center;
       transform: scaleY(0);
@@ -35,15 +35,15 @@
       left: 0.4375rem;
       width: 0.375rem;
       height: 0.75rem;
-      border-right: 2px solid color(neutral-3);
-      border-bottom: 2px solid color(neutral-3);
+      border-right: 2px solid var(--color-neutral-3);
+      border-bottom: 2px solid var(--color-neutral-3);
       transform: rotate(45deg), translateY(1.5rem);
       transition: all var(--time-sm) 150ms var(--timing-snap);
       opacity: 0;
     }
 
     &:hover {
-      box-shadow: 0 0 0 1px color(neutral-1);
+      box-shadow: 0 0 0 1px var(--color-neutral-1);
     }
 
     &:checked::before {

--- a/src/scss/2021/components/_form.scss
+++ b/src/scss/2021/components/_form.scss
@@ -10,10 +10,11 @@
     border-radius: 0;
     background: var(--color-neutral-3);
     border-left-width: 0.25rem;
+    transition: all var(--time-sm) var(--timing-snap);
 
-    &:hover, 
+    &:hover,
     &:focus {
-      box-shadow: inset 0 0 0 0.125rem var(--color-neutral-1);
+      box-shadow: inset 0 0 0 0.0625rem var(--color-neutral-1);
       border-left-width: 0.25rem;
     }
   }
@@ -33,7 +34,7 @@
     border-left-width: 0.25rem;
     transition: all var(--time-sm) 50ms var(--timing-snap);
 
-    &:hover, 
+    &:hover,
     &:focus {
       color: var(--color-neutral-3);
       background: var(--color-neutral-1);


### PR DESCRIPTION
- Add dark mode colors to checkboxes and the main CTA icon.
- Add transition values to the text input.

## Validation
- Open the deploy of this PR https://deploy-preview-291--angry-mirzakhani-365cef.netlify.app/2021
- Scroll to the main CTA at the bottom of the 2021 page.
- Verify that the checkbox inputs and the mail icon look correct compared to the [design](https://www.figma.com/proto/8qXWkVZG2BWmB29tZ320Hs/2021-DS-Survey?page-id=1%3A129&node-id=123%3A3&viewport=1426%2C2807%2C1&scaling=scale-down-width&hide-ui=1).
- Switch your computer to "dark mode" and again, verify that the checkbox and mail icon display in the same way but with reversed colors. You can do this on Mac by opening command center and clicking on "display"
  <img width="395" alt="Screen Shot 2021-07-06 at 1 58 01 PM" src="https://user-images.githubusercontent.com/19694054/124646056-2ee73e00-de62-11eb-8bdb-c9bdea20eb05.png">
