### PR TITLE
DES 72: Mobile hero font size

### DIFF
--- a/src/scss/2021/components/_intro.scss
+++ b/src/scss/2021/components/_intro.scss
@@ -23,12 +23,16 @@
 
   &__text {
     font-family: var(--font-mono);
-    font-size: mq(sm) * 0.1;
+    font-size: mq(sm) * 0.15;
     line-height: 0.875;
     font-weight: 200;
 
     @media(min-width: mq(sm)) {
-      font-size: 10vw;
+      font-size: 15vw;
+    }
+
+    @media(min-width: mq(md)) {
+      font-size: 12vw;
     }
 
     @media(min-width: mq(lg)) {
@@ -91,7 +95,7 @@
       display: block;
       padding-top: 100%;
     }
-    
+
     @include ie11 {
       display: none;
     }


### PR DESCRIPTION
Adjust font sizes of the main hero text to make it larger on mobile.

## Validate
- Open the deploy for this PR https://deploy-preview-292--angry-mirzakhani-365cef.netlify.app/2021/
- Verify that the font sizes for the hero text "2021 Design System Survey" is larger on mobile and tablet screen sizes but the same on desktop. 