### PR TITLE
DES 77:  IE 11 logo

### DIFF
--- a/src/scss/2021/components/_fixed-sides.scss
+++ b/src/scss/2021/components/_fixed-sides.scss
@@ -45,6 +45,11 @@
   transform: rotate(180deg);
   color: inherit;
 
+  @include ie11 {
+    // The 180deg rotation was causing layout issues in IE11
+    transform: none;
+  }
+
   &__svg {
     width: calc(21px * 0.75);
     height: calc(75px * 0.75);


### PR DESCRIPTION
Remove a CSS transform in IE 11 to fix a layout issue.

## Validation
- Open the deploy of this PR. https://deploy-preview-293--angry-mirzakhani-365cef.netlify.app/2021/
- Verify that nothing broke in a modern browser (Chrome, Firefox, or Safari). In particular, the fixed position Sparkbox logo that displays in the top left corner of the viewport.
- Verify that the fixed position Sparkbox logo is not covering up body content in IE11.