### PR TITLE
DES-76: Safari warning

### DIFF
--- a/src/pages/2021.js
+++ b/src/pages/2021.js
@@ -34,7 +34,6 @@ class Page2021 extends Component {
           <link href="https://fonts.googleapis.com/css2?family=Inconsolata:wght@300;700&display=swap" rel="stylesheet" media={ieCSS} />
           <link rel="preload" as="font" href="/fonts/2021/Inconsolata.woff2" type="font/woff2" crossorigin="anonymous" media={modernCSS} />
           <link rel="preload" as="font" href="/fonts/2021/SoleSans.woff2" type="font/woff2" crossorigin="anonymous" media={modernCSS} />
-          <link rel="preload" as="font" href="/fonts/2021/SoleSansItalic.woff2" type="font/woff2" crossorigin="anonymous" media={modernCSS} />
           <link rel="stylesheet" type="text/css" href="/css/2021.css" media={modernCSS} />
           <link rel="stylesheet" type="text/css" href="/css/2021-ie.css" media={ieCSS} />
         </Helmet>


### PR DESCRIPTION
Remove an unused font file that was being pre-loaded and throwing an error.

This does _not_ fix all of the warning messages but we determined this would be a good fix for now and we can ignore the remaining warnings since they are not breaking anything and there doesn't seem to be an obvious, quick fix.

## Validation
- Open the PR deploy
- Verify that there is no warning in the console in Chrome or Firefox that says something like " a certain resource was preloaded but not used within a few seconds of the window's load event"
- NOTE these messages will likely still display in Safari but we are saying that is a "won't fix." This PR specifically removes the font that was listed with a warning message for being pre-loaded so that should not be displayed in any browser.

This is what we were seeing before the PR. Note the first warning about the font file should not be there anymore.

<img width="915" alt="Screen Shot 2021-07-06 at 1 49 49 PM" src="https://user-images.githubusercontent.com/19694054/124645122-0ad72d00-de61-11eb-86bb-926347eccc2a.png">
