### PR TITLE
DES-65:  a11y tables

### DIFF
--- a/src/components/2021/stacked-chart-table.js
+++ b/src/components/2021/stacked-chart-table.js
@@ -7,9 +7,9 @@ const StackedChartTable = (props) => {
   let cellIterator = (value) => {
     let results = []
     for (let i = 0; i < value.length; i++) {
-      if (value[i] > 0) {
+      if (value[i] >= 0) {
         let result = value[i]
-        if (result) {
+        if (Number.isFinite(result)) {
           results.push (
             <td>
               {result}%

--- a/src/sections/2021/section-3.js
+++ b/src/sections/2021/section-3.js
@@ -192,7 +192,7 @@ const Section3 = () => (
           ]}
           dataPoints={[
             ['Not Successful', [33, 33, 17, 0, 17]],
-            ['Slightly Successful', [58, 32, 10]],
+            ['Slightly Successful', [58, 32, 10, 0, 0]],
             ['Moderately Successful', [17, 30, 22, 20, 12]],
             ['Successful', [10, 24, 36, 28, 2]],
             ['Very Successful', [8, 8, 25, 50, 8]]
@@ -278,7 +278,7 @@ const Section3 = () => (
             'They often or always contribute to the design system (4-5)',
           ]}
           dataPoints={[
-            ['Not Successful', [83, 0, 17]],
+            ['Not Successful', [83, 17, 0]],
             ['Slightly Successful', [68, 18, 14]],
             ['Moderately Successful', [48, 34, 18]],
             ['Successful', [49, 28, 23]],
@@ -509,7 +509,7 @@ const Section3 = () => (
             `I don't know`
           ]}
           dataPoints={[
-            ['Not Successful', [83, 17]],
+            ['Not Successful', [83, 17, 0]],
             ['Slightly Successful', [50, 32, 18]],
             ['Moderately Successful', [50, 34, 16]],
             ['Successful', [53, 32, 15]],


### PR DESCRIPTION
### Description

Stacked Bar Charts generate the correct amount of table data rows.

#### Validation

**Run the HTML through the through the [W3C Validator](https://validator.w3.org/) to ensure that none of the following errors exist**: 


Warning: A table row was 5 columns wide, which is less than the column count established by the first row (6).

From line 1, column 79380; to line 1, column 79384

`-->%</td></tr><tr><t`

Warning: A table row was 4 columns wide, which is less than the column count established by the first row (6).

From line 1, column 79490; to line 1, column 79494

`-->%</td></tr><tr><t`

Warning: A table row was 3 columns wide, which is less than the column count established by the first row (4).

From line 1, column 90242; to line 1, column 90246

`-->%</td></tr><tr><t`

Warning: A table row was 3 columns wide, which is less than the column count established by the first row (4).

From line 1, column 125703; to line 1, column 125707

`-->%</td></tr><tr><t`

Warning: A table row was 2 columns wide, which is less than the column count established by the first row (4).

From line 1, column 136484; to line 1, column 136488

`-->%</td></tr><tr><t`