### PR TITLE
DES-74: left align bar chart fig cap

### DIFF
--- a/src/sections/2021/section-1.js
+++ b/src/sections/2021/section-1.js
@@ -83,7 +83,7 @@ const Section1 = () => (
     </GridCell>
 
     <GridCell spanLG="6" rowSpanMD="2" className="util-margin-bottom-1xl util-margin-bottom-1xl@md">
-      <Figure count="1.3" caption="Responses: In-house: 217; Agency:&nbsp;159">
+      <Figure count="1.3" caption="Responses: In-house: 217; Agency:&nbsp;159" direction="left">
         <BarChart
           headingLevel="h3"
           startStyle="alt"
@@ -102,7 +102,7 @@ const Section1 = () => (
     </GridCell>
 
     <GridCell start="2" startMD="6" startLG="9" className="util-margin-bottom-1xl util-margin-top-20vh@md">
-      <Figure count="1.4" caption="Responses: In-house: 217; Agency:&nbsp;157">
+      <Figure count="1.4" caption="Responses: In-house: 217; Agency:&nbsp;157" direction="left">
         <BarChart
           headingLevel="h3"
           startStyle="alt"

--- a/src/sections/2021/section-2.js
+++ b/src/sections/2021/section-2.js
@@ -169,7 +169,7 @@ const Section2 = () => (
       </GridCell>
 
       <GridCell rowSpanMD="2" startMD="4" spanMD="6" startLG="7" spanLG="6" className="util-margin-bottom-1xl">
-        <Figure count="2.4" caption="Responses: 374">
+        <Figure count="2.4" caption="Responses: 374" direction="left">
           <BarChart
             styleFormat="large"
             title="Teams are lacking certain disciplines"

--- a/src/sections/2021/section-3.js
+++ b/src/sections/2021/section-3.js
@@ -25,7 +25,7 @@ const Section3 = () => (
     </GridCell>
 
     <GridCell span="3" spanLG="4" className="util-margin-bottom-1xl">
-      <Figure count="3.1" caption="Responses: 154 | Respondents were asked to select all that&nbsp;apply.">
+      <Figure count="3.1" caption="Responses: 154 | Respondents were asked to select all that&nbsp;apply." direction="left">
         <BarChart
           headingLevel="h3"
           title="Priorities"
@@ -51,7 +51,7 @@ const Section3 = () => (
     </GridCell>
 
     <GridCell start="2" span="3" startMD="6" startLG="7" spanLG="4" className="util-margin-bottom-1xl">
-    <Figure count="3.2" caption="Responses: 158 | Respondents were asked to select all that&nbsp;apply.">
+    <Figure count="3.2" caption="Responses: 158 | Respondents were asked to select all that&nbsp;apply." direction="left">
       <BarChart
         headingLevel="h3"
         title="Challenges"
@@ -156,7 +156,7 @@ const Section3 = () => (
     </GridCell>
 
     <GridCell spanMD="6" className="util-margin-bottom-2xl util-margin-bottom-3xl@lg">
-      <Figure count="3.5" caption="Responses: 157 | Respondents were asked to select all that apply for “What are the top challenges your design system team is facing at this moment?">
+      <Figure count="3.5" caption="Responses: 157 | Respondents were asked to select all that apply for “What are the top challenges your design system team is facing at this moment?" direction="left">
         <BarChart
           headingLevel="h3"
           styleFormat="large"
@@ -297,7 +297,7 @@ const Section3 = () => (
     </GridCell>
 
     <GridCell span="3" spanMD="5" rowSpanMD="2" alignMD="end" spanLG="6" className="util-margin-bottom-1xl util-margin-bottom-3xl@md">
-      <Figure count="3.9" caption="Responses: 136 | Answers were on a scale of 1 to&nbsp;5.">
+      <Figure count="3.9" caption="Responses: 136 | Answers were on a scale of 1 to&nbsp;5." direction="left">
         <BarChart
           headingLevel="h3"
           title="But contribution is low"
@@ -385,7 +385,7 @@ const Section3 = () => (
     </GridCell>
 
     <GridCell start="2" startMD="1" spanMD="5" spanLG="6" className="util-margin-bottom-1xl">
-      <Figure count="3.12" caption="Respondents: 136 | Answers were on a scale of 1 to&nbsp;5.">
+      <Figure count="3.12" caption="Respondents: 136 | Answers were on a scale of 1 to&nbsp;5." direction="left">
         <BarChart
           headingLevel="h3"
           title="But most systems don’t have a well-defined process"

--- a/src/sections/2021/section-4.js
+++ b/src/sections/2021/section-4.js
@@ -52,7 +52,7 @@ const Section4 = () => (
     </GridCell>
 
     <GridCell startMD="7" spanLG="5" align="end" className="util-margin-top-3xl@md util-margin-bottom-1xl util-margin-bottom-3xl@md">
-      <Figure count="4.2" caption="Responses: 160" className="util-margin-bottom-1xl">
+      <Figure count="4.2" caption="Responses: 160" className="util-margin-bottom-1xl" direction="left">
         <BarChart
           headingLevel="h3"
           styleFormat="small"
@@ -115,7 +115,7 @@ const Section4 = () => (
     </GridCell>
 
     <GridCell startMD="2" spanMD="5" startLG="3" spanLG="6" className="util-margin-bottom-1xl">
-      <Figure count="4.4" caption="Responses: 38 | Respondents were asked to select all that&nbsp;apply.">
+      <Figure count="4.4" caption="Responses: 38 | Respondents were asked to select all that&nbsp;apply." direction="left">
         <BarChart
           headingLevel="h3"
           styleFormat="small"

--- a/src/sections/2021/section-5.js
+++ b/src/sections/2021/section-5.js
@@ -25,7 +25,7 @@ const Section5 = () => (
     </GridCell>
 
     <GridCell alignMD="end" rowSpanMD="2" startLG="3" className="util-margin-bottom-1xl">
-      <Figure count="5.1" caption="Responses: 136">
+      <Figure count="5.1" caption="Responses: 136" direction="left">
         <BarChart
           sizeFormat="small"
           headingLevel="h3"
@@ -89,7 +89,7 @@ const Section5 = () => (
     </GridCell>
 
     <GridCell startMD="2" startLG="3" className="util-margin-bottom-1xl">
-      <Figure count="5.2" caption="Responses: 136">
+      <Figure count="5.2" caption="Responses: 136" direction="left">
         <BarChart
           sizeFormat="small"
           headingLevel="h3"


### PR DESCRIPTION
### Description 
There are instances where bar chart figure captions appear to be floating on their own due to the arrangement of the chart.
Like so.. 
![image](https://user-images.githubusercontent.com/24901036/124663607-51845180-de78-11eb-8b37-681ca7d76306.png)
![image](https://user-images.githubusercontent.com/24901036/124663632-58ab5f80-de78-11eb-8d8d-e6346f4a5cbe.png)


Each of the instances for the bar chart captions has been aligned to the left instead. 


#### Validation
Open the deploy for this PR: https://deploy-preview-297--angry-mirzakhani-365cef.netlify.app/2021/
Review the entire page to make sure that there are no instances where the figure for a barchart appears to be floating on its own.
