### PR TITLE
DES-78:  figcaption render html

### DIFF
--- a/src/components/2021/figure.js
+++ b/src/components/2021/figure.js
@@ -12,7 +12,7 @@ const Figure = (props) => {
         <span className="cmp-figure__count">
           <abbr title="Figure">Fig</abbr>&nbsp;{props.count}
         </span>
-        <span>{props.caption}</span>
+        <span dangerouslySetInnerHTML={{__html:props.caption}} />
       </figcaption>
     </figure>
   )


### PR DESCRIPTION
### Description
Render HTML in figure caption

#### Validation
use `<strong>` or `<em>` within a figure caption to make sure that HTML is rendered correctly