### PR TITLE
DES 79 & 80: em dashes

### DIFF
--- a/src/sections/2021/section-1.js
+++ b/src/sections/2021/section-1.js
@@ -107,7 +107,7 @@ const Section1 = () => (
           headingLevel="h3"
           startStyle="alt"
           styleFormat="small"
-          title="How many people are employed by your organization?"
+          title={<>How many people are <em>employed</em> by your organization?</>}
           keyMap={['In-house', 'Agency']}
           dataPoints={[
             ['1-50 Employees', [10, 54]],

--- a/src/sections/2021/section-3.js
+++ b/src/sections/2021/section-3.js
@@ -21,7 +21,7 @@ const Section3 = () => (
     </GridCell>
 
     <GridCell spanLG="6" className="util-margin-bottom-1xl util-margin-bottom-3xl@md">
-      <p className="cmp-type-body-large">As noted in the <a href="/2020/">2020 Design Systems Survey</a>, “Due to the nature of a design system requiring buy-in and support from multiple disciplines, a design system project often helps break down organizational silos.” Design system teams focus on common areas—many of which highlight the importance of cross-team support.</p>
+      <p className="cmp-type-body-large">As noted in the <a href="/2020/">2020 Design Systems Survey</a>, “Due to the nature of a design system requiring buy-in and support from multiple disciplines, a design system project often helps break down organizational silos.” Design system teams focus on common areas&#8202;&mdash;&#8202;many of which highlight the importance of cross-team support.</p>
     </GridCell>
 
     <GridCell span="3" spanLG="4" className="util-margin-bottom-1xl">

--- a/src/sections/2021/section-4.js
+++ b/src/sections/2021/section-4.js
@@ -18,7 +18,7 @@ const Section4 = () => (
     </GridCell>
 
     <GridCell spanLG="6" className="util-margin-bottom-1xl util-margin-bottom-3xl@md">
-      <p className="cmp-type-body-large">46% of in-house respondents have dedicated design system teams&mdash;but even non-dedicated teams have to get approval to spend time on the system. While the promise of a design system may be enough to gain support on day one, as systems get older, it’s natural that teams need to prove their value. Enter metrics.</p>
+      <p className="cmp-type-body-large">46% of in-house respondents have dedicated design system teams&#8202;&mdash;&#8202;but even non-dedicated teams have to get approval to spend time on the system. While the promise of a design system may be enough to gain support on day one, as systems get older, it’s natural that teams need to prove their value. Enter metrics.</p>
     </GridCell>
 
     <GridCell startMD="7" startLG="11">


### PR DESCRIPTION
**DES-79**
- Add spaces around em dashes that appear in the monospace font to help them appear more like em dashes. This was approved by Kaitlyn.

**DES-80**
- This chart title should have red on “employed” like "How many people are employed by your organization?"