### PR TITLE
DES 89: Scorecard placement

### DIFF
--- a/src/sections/2021/section-3.js
+++ b/src/sections/2021/section-3.js
@@ -116,7 +116,7 @@ const Section3 = () => (
       <ArtElement type="bars" />
     </GridCell>
 
-    <GridCell spanMD="6" className="util-margin-bottom-1xl">
+    <GridCell className="util-margin-bottom-1xl">
       <Figure count="3.4" direction="left">
       <ScoreRow>
         <ScoreCardLarge border={false}>


### PR DESCRIPTION
Make all sub-section scorecards the same width.

Visually, there might not be much of a difference but you should see that figures 3.4, 3.7, and 3.13 all have the same grid layout properties now.

