### PR TITLE
DES-98: Fix overflowing content

### DIFF
--- a/src/sections/2021/section-3.js
+++ b/src/sections/2021/section-3.js
@@ -91,7 +91,7 @@ const Section3 = () => (
           </ScoreCardLarge>
           <ScoreCardLarge border={false}>
             <Number bold={true}>2</Number>
-            <p class="cmp-type-h3">Engaging Contributors</p>
+            <p class="cmp-type-h3">Engaging<br />Contri&shy;butors</p>
           </ScoreCardLarge>
           <ScoreCardLarge border={false}>
             <Number bold={true}>3</Number>


### PR DESCRIPTION
This adds the `&shy;` special character to the word ** Contributors**. Because of how `&shy;` works, a `<br />` was also added to force a two-line presentation of the content.