### PR TITLE
DES-103:  semantic headings

### DIFF
--- a/src/sections/2021/section-1.js
+++ b/src/sections/2021/section-1.js
@@ -45,7 +45,7 @@ const Section1 = () => (
 
     <GridCell start="2" span="3" rowSpanMD="2" startMD="6" spanMD="3" startLG="9" spanLG="4" className="util-margin-bottom-1xl util-margin-top-20vh@md">
       <Figure count="1.2" caption="Responses: In-house: 217; Agency: 159">
-        <h2 class="cmp-type-h3">What is your primary discipline?</h2>
+        <h3>What is your primary discipline?</h3>
 
         <h3><em>In-House</em></h3>
         <ScoreRow>

--- a/src/sections/2021/section-2.js
+++ b/src/sections/2021/section-2.js
@@ -24,6 +24,7 @@ const Section2 = () => (
       <GridCell span="3" spanMD="4" spanLG="6" className="util-margin-bottom-1xl util-margin-bottom-md@md">
         <Figure count="2.1" caption="Responses: 159" direction="left">
           <PieChart
+            headingLevel="h3"
             styleFormat="large"
             title="Almost 40% of systems were successful or very successful"
             dataPoints={[
@@ -49,6 +50,7 @@ const Section2 = () => (
       <GridCell start="2" span="3" startMD="3" spanMD="6" startLG="6" spanLG="7" className="util-margin-bottom-1xl util-margin-bottom-2xl@md">
         <Figure count="2.2" caption="Responses: 171">
           <PieChart
+            headingLevel="h3"
             title="Individual contributor(s) suggested starting a design system"
             dataPoints={[
               ['Individual contributor(s) suggested starting a design system', 57],
@@ -66,7 +68,7 @@ const Section2 = () => (
       <GridCell span="4" spanMD="6" spanLG="6" className="util-margin-bottom-1xl util-margin-bottom-3xl@lg">
         <Figure count="2.3" direction="left" caption="Responses: 171 | Respondents were asked to select all that apply from a list of 19 items with an option to enter other&nbsp;answers.">
 
-          <h2 class="cmp-type-h3">Design systems have similar elements</h2>
+          <h3>Design systems have similar elements</h3>
           <p>"What does your design system <em>contain</em>?"</p>
 
           <ScoreRow>
@@ -171,6 +173,7 @@ const Section2 = () => (
       <GridCell rowSpanMD="2" startMD="4" spanMD="6" startLG="7" spanLG="6" className="util-margin-bottom-1xl util-margin-bottom-2xl@lg">
         <Figure count="2.4" caption="Responses: 374" direction="left">
           <BarChart
+            headingLevel="h3"
             styleFormat="large"
             title="Teams are lacking certain disciplines"
             keyMap={[

--- a/src/sections/2021/section-3.js
+++ b/src/sections/2021/section-3.js
@@ -82,7 +82,7 @@ const Section3 = () => (
 
     <GridCell startLG="7" spanLG="6" className="util-margin-bottom-1xl">
       <Figure count="3.3">
-        <h2 class="cmp-type-h3">Top priorities and challenges</h2>
+        <h3>Top priorities and challenges</h3>
         <p>Across both top priorities and challenges, three areas stood out, which we will explore more deeply in the next sections.</p>
         <ScoreRow>
           <ScoreCardLarge border={false}>
@@ -134,7 +134,7 @@ const Section3 = () => (
     </GridCell>
 
     <GridCell className="util-margin-bottom-1xl">
-      <h2 class="cmp-type-h3">Adoption continues to be a focus for many teams</h2>
+      <h3>Adoption continues to be a focus for many teams</h3>
       <p>Adoption difficulties have been high on respondents’ lists of concerns since our <a href="/2018/">2018 Design Systems Survey</a> and remain there in 2021.</p>
     </GridCell>
 

--- a/src/sections/2021/section-4.js
+++ b/src/sections/2021/section-4.js
@@ -28,6 +28,7 @@ const Section4 = () => (
     <GridCell span="3" spanMD="4" className="util-margin-bottom-1xl util-margin-bottom-3xl@md">
       <Figure count="4.1" caption="Responses: 159" className="util-margin-bottom-1xl">
         <StackedChart
+          headingLevel="h3"
           styleFormat="small"
           title="Tracking metrics is linked to success"
           keyMap={[


### PR DESCRIPTION
There were several instances of `<h2>` that followed after the main section heading level 2. 
- I updated all of the instances of extra `<h2>`'s to be an `<h3>` 
This corrected the issue of the `<h4>` following immediately behind the `<h2>`. The `<h2>` has been changed to an `<h3>`

Now there should only be one `<h2>` per section. 

<img width="706" alt="Screen Shot 2021-07-08 at 2 34 55 PM" src="https://user-images.githubusercontent.com/24901036/124973554-abf8eb80-dff9-11eb-99b7-24021f637d06.png">

<img width="724" alt="Screen Shot 2021-07-08 at 2 34 40 PM" src="https://user-images.githubusercontent.com/24901036/124973529-a4394700-dff9-11eb-8bac-11e2435d41e8.png">

