### PR TITLE
DES 105: aria hidden fixes

### DIFF
--- a/src/components/2021/bar-chart.js
+++ b/src/components/2021/bar-chart.js
@@ -12,7 +12,7 @@ const BarChart = (props) => {
   if (props.startStyle === 'alt') {
     fillStart = 6
   }
-  
+
   // Chart Key
   if (props.keyMap) {
     for (let i = 0; i < props.keyMap.length; i++) {
@@ -25,7 +25,7 @@ const BarChart = (props) => {
       );
     }
   }
-  
+
   // Single Bar
   let barIterator = (...value) => {
     let results = []
@@ -68,7 +68,7 @@ const BarChart = (props) => {
   return (
     <>
       <div className={`cmp-bar-chart cmp-bar-chart--${props.styleFormat}`}>
-        <Tag className="cmp-type-h3">{props.title}</Tag>
+        <Tag aria-hidden="true" className="cmp-type-h3">{props.title}</Tag>
         {props.children}
         <div aria-hidden="true" className="cmp-bar-chart__keys">
           {keysMap}

--- a/src/components/2021/pie-chart.js
+++ b/src/components/2021/pie-chart.js
@@ -24,7 +24,7 @@ const PieChart = (props) => {
       <div className={`cmp-pie-chart__slice cmp-pie-chart__slice--object-${i + 1} util-fill-style-${i + 1}`} />
     );
   }
-  
+
   cssProperties['--total'] = 'calc(var(--object-1) + var(--object-2) + var(--object-3) + var(--object-4) + var(--object-5))'
   cssProperties['--turn-1'] = 'calc((var(--object-1) / var(--total)) * 360deg)'
   cssProperties['--turn-2'] = 'calc(((var(--object-2) / var(--total)) * 360deg) + var(--turn-1))'
@@ -35,7 +35,7 @@ const PieChart = (props) => {
   return (
     <div className={`cmp-pie-chart cmp-pie-chart--${props.styleFormat}`}>
       <div className="cmp-pie-chart__keys-container">
-        <Tag className="cmp-type-h3 cmp-pie-chart__title">{props.title}</Tag>
+        <Tag aria-hidden="true" className="cmp-type-h3 cmp-pie-chart__title">{props.title}</Tag>
         {props.children}
         <table className="cmp-pie-chart__keys">
           <caption className="util-visually-hidden">{props.title}</caption>

--- a/src/components/2021/section-header.js
+++ b/src/components/2021/section-header.js
@@ -18,7 +18,8 @@ const SectionHeader = ({title, number, total}) => {
 
   return (
     <header className="cmp-section-header" data-number={number}>
-      <h2 className="cmp-section-header__title">{title}</h2>
+      <div aria-hidden="true" className="cmp-section-header__number">0{number}</div>
+      <h2 aria-label={`Section ${number}: ${title}`} className="cmp-section-header__title">{title}</h2>
       <div className="cmp-section-header__marker" aria-hidden="true">
         <svg width="104" height="24" viewBox="0 0 104 24" fill="none" xmlns="http://www.w3.org/2000/svg">
           { markers }
@@ -34,12 +35,12 @@ SectionHeader.defaultProps = {
   number: 1,
   total: 6
 }
-  
+
 SectionHeader.propTypes = {
   title: PropTypes.string.isRequired,
   number: PropTypes.number.isRequired,
   total: PropTypes.number.isRequired,
 }
-  
-  
+
+
   export default SectionHeader

--- a/src/components/2021/stacked-chart.js
+++ b/src/components/2021/stacked-chart.js
@@ -42,7 +42,7 @@ const StackedChart = (props) => {
       <>{results}</>
     )
   }
-  
+
   for (let i = 0; i < props.dataPoints.length; i++) {
     dataBars.push(
       <div className="cmp-stacked-chart__set">
@@ -59,7 +59,7 @@ const StackedChart = (props) => {
   return (
     <>
       <div className={`cmp-stacked-chart cmp-stacked-chart--${props.styleFormat}`}>
-        <Tag className="cmp-type-h3">{props.title}</Tag>
+        <Tag aria-hidden="true" className="cmp-type-h3">{props.title}</Tag>
         {props.children}
         <div aria-hidden="true" className="cmp-stacked-chart__keys">
           {keysMap}

--- a/src/scss/2021/components/_section-header.scss
+++ b/src/scss/2021/components/_section-header.scss
@@ -4,7 +4,7 @@
   position: relative;
   margin-bottom: 3rem;
 
-  &::before {
+  &__number {
     position: absolute;
     z-index: -1;
     content: "0" attr(data-number);


### PR DESCRIPTION
## Description

Resolves the following bugs:

- Charts need to have the heading set to `aria-hidden="true"` as the table caption is what provides this information.

- Section Heading numbers (outlined large number) needs set to `aria-hidden="true"`

## Validation
- Open the PR deploy
- Use voiceover to ensure that there are no duplicated headings on charts and that the section header text reads correctly
- Ensure nothing broke on the page with the changes to the section header component.