### PR TITLE
DES-104:  Section 3 Heading Spacing

### DIFF
--- a/src/sections/2021/section-3.js
+++ b/src/sections/2021/section-3.js
@@ -108,7 +108,7 @@ const Section3 = () => (
 
 
 
-    <GridCell spanMD="6" className="util-margin-bottom-1xl">
+    <GridCell spanMD="6" className="util-margin-bottom-xl">
       <h2>1 - Encouraging Adoption</h2>
     </GridCell>
 


### PR DESCRIPTION
The spacing for the first subsection within section 3 had more spacing than other subsections. 

![image](https://user-images.githubusercontent.com/24901036/125095596-588ea800-e0a2-11eb-9913-ee21aa41d57f.png)

- Quick fix to remove that extra margin-bottom so that each section's spacing is consistent. 

Each sub section heading should have equal spacing on mobile and desktop. 