### PR TITLE
DES: pre launch

### DIFF
--- a/src/scss/2020/components/_site-header.scss
+++ b/src/scss/2020/components/_site-header.scss
@@ -83,4 +83,9 @@
       transform: translate(-10vw, -10vh);
     }
   }
+
+  &__link {
+    --link: #{color(blue)};
+    --link-hover: #{lighten(color(blue), 5%)};
+  }
 }

--- a/src/sections/2020/intro.mdx
+++ b/src/sections/2020/intro.mdx
@@ -7,6 +7,9 @@
       </a>
     </h2>
     <div class="cmp-site-header__container">
+      <div className="cmp-site-header__link util-pad-vertical-lg cmp-fade-in js-watch" data-animate="cmp-fade-in--animate">
+        <p><a href="https://designsystemssurvey.seesparkbox.com/">Check out the results from the latest Design Systems Survey</a></p>
+      </div>
       <div aria-hidden="true" class="cmp-site-header__icon cmp-fade-up js-watch" data-animate="cmp-fade-up--animate">
         <div class="cmp-icon cmp-icon--chart cmp-icon--hero"></div>
       </div>

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,2 +1,2 @@
 # Manually set redirects
-/     /2020/      302!
+/     /2021/      302!


### PR DESCRIPTION
- Update 2020 to have a link to designsystemssurvey.seesparkbox.com
- Update static/_redirects to redirect / to /2021 so 2021 becomes the new default page