### PR TITLE
feat: add horizontal divider lines above chart headings

### DIFF
--- a/src/sections/2021/section-1.js
+++ b/src/sections/2021/section-1.js
@@ -23,6 +23,7 @@ const Section1 = () => (
     </GridCell>
 
     <GridCell spanLG="4" className="util-margin-bottom-1xl util-margin-bottom-20vh@md">
+      <hr className="util-hr-solid util-margin-vertical-lg" />
       <Figure count={1.1} caption="376 Responses">
         <ScoreRow>
           <ScoreCardLarge border={false}>
@@ -44,6 +45,7 @@ const Section1 = () => (
     </GridCell>
 
     <GridCell start="2" span="3" rowSpanMD="2" startMD="6" spanMD="3" startLG="9" spanLG="4" className="util-margin-bottom-1xl util-margin-top-20vh@md">
+      <hr className="util-hr-solid util-margin-vertical-lg" />
       <Figure count={1.2} caption="Responses: In-house: 217; Agency: 159">
         <h3>What is your primary discipline?</h3>
 

--- a/src/sections/2021/section-2.js
+++ b/src/sections/2021/section-2.js
@@ -66,8 +66,9 @@ const Section2 = () => (
       </GridCell>
 
       <GridCell span="4" spanMD="6" spanLG="6" className="util-margin-bottom-1xl util-margin-bottom-3xl@lg">
+        <hr className="util-hr-solid util-margin-vertical-lg" />
+        
         <Figure count={2.3} direction="left" caption="Responses: 171 | Respondents were asked to select all that apply from a list of 19 items with an option to enter other&nbsp;answers.">
-
           <h3>Design systems have similar elements</h3>
           <p>"What does your design system <em>contain</em>?"</p>
 
@@ -202,6 +203,7 @@ const Section2 = () => (
       </GridCell>
 
       <GridCell spanMD="6">
+        <hr className="util-hr-solid util-margin-vertical-lg" />
         <Figure count={2.5} caption="Responses: 136">
           <h3>Most respondent organizations have centralized teams</h3>
           <p>&ldquo;How is your design system <em>team structured</em>?&rdquo;</p>

--- a/src/sections/2021/section-3.js
+++ b/src/sections/2021/section-3.js
@@ -81,6 +81,7 @@ const Section3 = () => (
     </GridCell>
 
     <GridCell startLG="7" spanLG="6" className="util-margin-bottom-1xl">
+      <hr className="util-hr-solid util-margin-vertical-lg" />
       <Figure count={3.3}>
         <h3>Top priorities and challenges</h3>
         <p>Across both top priorities and challenges, three areas stood out, which we will explore more deeply in the next sections.</p>
@@ -106,7 +107,9 @@ const Section3 = () => (
     </GridCell>
 
 
-
+    <GridCell span="3" spanMD="6">
+      <hr className="util-hr-solid util-margin-vertical-lg" />
+    </GridCell>
 
     <GridCell spanMD="6" className="util-margin-bottom-xl">
       <h2>1 - Encouraging Adoption</h2>
@@ -237,10 +240,11 @@ const Section3 = () => (
     </GridCell>
 
 
-
+    <GridCell span="3" spanMD="4">
+      <hr className="util-hr-solid util-margin-vertical-lg" />
+    </GridCell>
 
     <GridCell spanMD="4" className="util-margin-bottom-1xl util-margin-bottom-3xl@md">
-
       <h2>2 - Engaging Contributors</h2>
 
       <Figure count={3.7} direction="left">
@@ -415,6 +419,9 @@ const Section3 = () => (
     </GridCell>
 
 
+    <GridCell span="3" spanMD="4">
+      <hr className="util-hr-solid util-margin-vertical-lg" />
+    </GridCell>
 
     <GridCell spanMD="4" className="util-margin-bottom-1xl">
       <h2>3 - Overcoming Debt</h2>

--- a/src/sections/2021/section-4.js
+++ b/src/sections/2021/section-4.js
@@ -73,6 +73,7 @@ const Section4 = () => (
     </GridCell>
 
     <GridCell spanLG="6" className="util-margin-bottom-1xl util-margin-bottom-3xl@md">
+      <hr className="util-hr-solid util-margin-vertical-lg" />
       <Figure count={4.3} caption="Responses: 50">
         <h3>Design system teams track similar metrics</h3>
         <p>“<em>Which metrics</em> are you tracking?”</p>


### PR DESCRIPTION
- Updates all areas where horizontal divider lines above chart headings are missing

I found 6 instances, and excluded horizontal lines from above sub header sections in section 3.