### PR TITLE
fix: JS Animation and Section 3 layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "react-anchor-link-smooth-scroll": "^1.0.12",
         "react-dom": "^16.14.0",
         "react-helmet": "^6.1.0",
-        "react-transition-group": "^4.4.2",
         "rellax": "^1.12.1",
         "run-all": "^1.0.1",
         "sass": "^1.34.1",
@@ -15001,10 +15000,7 @@
     "node_modules/jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "engines": {
-        "node": "*"
-      }
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "node_modules/jsonp": {
       "version": "0.2.1",
@@ -22464,9 +22460,6 @@
         "lodash": "^4.0.0",
         "scss-tokenizer": "^0.2.3",
         "yargs": "^13.3.2"
-      },
-      "bin": {
-        "sassgraph": "bin/sassgraph"
       }
     },
     "node_modules/sass-graph/node_modules/cliui": {
@@ -23766,11 +23759,6 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -44847,8 +44835,7 @@
       "requires": {}
     },
     "react-transition-group": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
+      "version": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
       "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
       "requires": {
         "@babel/runtime": "^7.5.5",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "react-anchor-link-smooth-scroll": "^1.0.12",
     "react-dom": "^16.14.0",
     "react-helmet": "^6.1.0",
-    "react-transition-group": "^4.4.2",
     "rellax": "^1.12.1",
     "run-all": "^1.0.1",
     "sass": "^1.34.1",

--- a/src/components/2021/intro.js
+++ b/src/components/2021/intro.js
@@ -3,7 +3,6 @@ import Grid from "./grid"
 import GridCell from "./grid-cell"
 import SVGArrow from "./svg-arrow"
 import ArtElement from "../../components/2021/art-element"
-import { CSSTransition } from 'react-transition-group'
 
 const SiteIntro = (props) => {
   return (
@@ -12,40 +11,12 @@ const SiteIntro = (props) => {
       <div aria-hidden="true">
         <div className="cmp-intro__text cmp-intro__text--year">2021</div>
         <div className="cmp-intro__title-container">
-          <CSSTransition
-            in={true}
-            timeout={5000}
-            className="cmp-intro__text cmp-intro__text--transition"
-            appear
-          >
-            <div>Design</div>
-          </CSSTransition>
-          <CSSTransition
-            in={true}
-            timeout={5000}
-            className="cmp-intro__text cmp-intro__text--transition"
-            appear
-          >
-            <div>Systems</div>
-          </CSSTransition>
-          <CSSTransition
-            in={true}
-            timeout={5000}
-            className="cmp-intro__text cmp-intro__text--transition"
-            appear
-          >
-            <div>Survey</div>
-          </CSSTransition>
-          <CSSTransition
-            in={true}
-            timeout={6000}
-            className="cmp-intro__art-element--transition"
-            appear
-          >
-            <div>
-              <ArtElement isHero={true} />
-            </div>
-          </CSSTransition>
+          <div className="cmp-intro__text cmp-intro__text--transition">Design</div>
+          <div className="cmp-intro__text cmp-intro__text--transition">Systems</div>
+          <div className="cmp-intro__text cmp-intro__text--transition">Survey</div>
+          <div className="cmp-intro__art-element--transition">
+            <ArtElement isHero={true} />
+          </div>
         </div>
       </div>
       {props.children}

--- a/src/scss/2021/components/_intro.scss
+++ b/src/scss/2021/components/_intro.scss
@@ -130,31 +130,33 @@ $animation-delay-factor: 250ms;
 
   // Transition styles
 
-  .js &__text--transition,
-  .js &__art-element--transition {
+  &__text--transition,
+  &__art-element--transition {
     // Hide elements that will animate if JS is active
     opacity: 0;
   }
 
-  .js &__text--transition.appear-done,
-  .js &__art-element--transition.appear,
-  .js &__art-element--transition.appear-done {
+  &__text--transition,
+  &__art-element--transition,
+  &__art-element--transition {
     // Show elements after animation has run
     opacity: 1;
   }
 
-  .js &__text--transition.appear-active {
+  &__text--transition {
     animation-name: enter;
+    animation-fill-mode: forwards;
     animation-duration: var(--time-xl);
     animation-timing-function: var(--timing-smooth);
     animation-fill-mode: both;
   }
 
   @for $i from 1 through 4 {
-    &__art-element--transition.appear-active path:nth-child(#{$i}) {
+    &__art-element--transition path:nth-child(#{$i}) {
       // Stagger in animation for the art element in the intro component
       animation-name: enterMove;
       animation-duration: var(--time-xl);
+      animation-fill-mode: forwards;
 
       // This delay calculation adds the time for the text animation plus a new delay
       // factor for this art element animation. This factor is subtracted because

--- a/src/scss/2021/utilities/_display.scss
+++ b/src/scss/2021/utilities/_display.scss
@@ -1,3 +1,7 @@
 .util-height-full {
     height: 100vh;
 }
+
+.util-display-flex {
+    display: flex;
+}

--- a/src/sections/2021/section-3.js
+++ b/src/sections/2021/section-3.js
@@ -108,12 +108,12 @@ const Section3 = () => (
     </GridCell>
 
 
-    <GridCell span="3" spanMD="6">
+    <GridCell>
       <hr className="util-hr-solid util-margin-vertical-lg" />
     </GridCell>
 
-    <GridCell spanMD="6" className="util-margin-bottom-xl">
-      <h2>1 - Encouraging Adoption</h2>
+    <GridCell className="util-margin-bottom-xl">
+      <h2 className="cmp-type-h2 util-display-flex" aria-label="1 - Encouraging Adoption"><div>1&nbsp;-&nbsp;</div><div>Encouraging Adoption</div></h2>
     </GridCell>
 
     <GridCell align="center" rowSpanMD="2" startMD="8" startLG="12">
@@ -246,7 +246,7 @@ const Section3 = () => (
     </GridCell>
 
     <GridCell spanMD="4" className="util-margin-bottom-1xl util-margin-bottom-3xl@md">
-      <h2>2 - Engaging Contributors</h2>
+      <h2 className="cmp-type-h2 util-display-flex" aria-label="2 - Engaging Contributors"><div>2&nbsp;-&nbsp;</div><div>Engaging Contributors</div></h2>
 
       <Figure count={3.7} direction="left">
         <ScoreRow>
@@ -425,7 +425,7 @@ const Section3 = () => (
     </GridCell>
 
     <GridCell spanMD="4" className="util-margin-bottom-1xl">
-      <h2>3 - Overcoming Debt</h2>
+      <h2 className="cmp-type-h2 util-display-flex" aria-label="3 - Overcoming Debt"><div>3&nbsp;-&nbsp;</div><div>Overcoming Debt</div></h2>
 
       <Figure count={3.13} direction="left">
         <ScoreRow>


### PR DESCRIPTION
This does two things:
1. The intro animation was setup to require JS in order to do what the CSS property `animation-fill-mode: forwards;` accomplishes. So, the JS requirements were removed and the CSS property added.
2. The second thing has to do with the display of the Priority/Challenge headings as the screen sizes changes. Which does two things as well: The first is that is makes them all consistent, as the first on of these groups was wider. The second thing is it adds some alignment HTML to better handle wrapping. See the following screenshots:

<img width="549" alt="image" src="https://user-images.githubusercontent.com/1128391/125971342-719ff2f0-7c2b-42ea-bb0c-74813d6374d7.png">
<img width="484" alt="image" src="https://user-images.githubusercontent.com/1128391/125971398-cf766f47-168d-455b-afcc-90983b9251bc.png">
