### PR TITLE
Load Fonts from assets.sparkbox.com

### DIFF
--- a/src/pages/2020.js
+++ b/src/pages/2020.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react"
 import Layout from '../components/2020/layout'
 import SEO from '../components/SEO'
+import Helmet from 'react-helmet'
 import SiteFooter from '../components/2020/footer'
 import IntroSection from '../sections/2020/intro'
 import TableOfContents from '../sections/2020/table-of-contents'
@@ -25,6 +26,11 @@ class Page2020 extends Component {
           image="ogimage-2020.png"
           year="2020"
         />
+        <Helmet>
+          <link rel="preload" as="font" href="https://assets.sparkbox.com/fonts/sole/sole-sans-vf-regular-extra-condensed/font.woff2" type="font/woff2" crossorigin="anonymous" />
+          <link rel="preload" as="font" href="https://assets.sparkbox.com/fonts/solesole-serif-headline-extrabold/font.woff2" type="font/woff2" crossorigin="anonymous" />
+          <link rel="preload" as="font" href="https://assets.sparkbox.com/fonts/solesole-serif-text-light/font.woff2" type="font/woff2" crossorigin="anonymous" />
+        </Helmet>
         <IntroSection />
         <main>
           <TableOfContents />

--- a/src/pages/2020.js
+++ b/src/pages/2020.js
@@ -28,8 +28,8 @@ class Page2020 extends Component {
         />
         <Helmet>
           <link rel="preload" as="font" href="https://assets.sparkbox.com/fonts/sole/sole-sans-vf-regular-extra-condensed/font.woff2" type="font/woff2" crossorigin="anonymous" />
-          <link rel="preload" as="font" href="https://assets.sparkbox.com/fonts/solesole-serif-headline-extrabold/font.woff2" type="font/woff2" crossorigin="anonymous" />
-          <link rel="preload" as="font" href="https://assets.sparkbox.com/fonts/solesole-serif-text-light/font.woff2" type="font/woff2" crossorigin="anonymous" />
+          <link rel="preload" as="font" href="https://assets.sparkbox.com/fonts/sole/sole-serif-headline-extrabold/font.woff2" type="font/woff2" crossorigin="anonymous" />
+          <link rel="preload" as="font" href="https://assets.sparkbox.com/fonts/sole/sole-serif-text-light/font.woff2" type="font/woff2" crossorigin="anonymous" />
         </Helmet>
         <IntroSection />
         <main>

--- a/src/pages/2021.js
+++ b/src/pages/2021.js
@@ -42,7 +42,7 @@ class Page2021 extends Component {
         <Helmet>
           <link href="https://fonts.googleapis.com/css2?family=Inconsolata:wght@300;700&display=swap" rel="stylesheet" media={ieCSS} />
           <link rel="preload" as="font" href="/fonts/2021/Inconsolata.woff2" type="font/woff2" crossorigin="anonymous" media={modernCSS} />
-          <link rel="preload" as="font" href="/fonts/2021/SoleSans.woff2" type="font/woff2" crossorigin="anonymous" media={modernCSS} />
+          <link rel="preload" as="font" href="https://assets.sparkbox.com/fonts/sole/sole-sans-vf-regular-extra-condensed/font.woff2" type="font/woff2" crossorigin="anonymous" media={modernCSS} />
           <link rel="stylesheet" type="text/css" href="/css/2021.css" media={modernCSS} />
           <link rel="stylesheet" type="text/css" href="/css/2021-ie.css" media={ieCSS} />
         </Helmet>

--- a/src/scss/2020/generic/_fonts.scss
+++ b/src/scss/2020/generic/_fonts.scss
@@ -9,16 +9,16 @@
 
 @font-face {
   font-family: "Sole Sans Serif";
-  src: url('https://assets.sparkbox.com/fonts/solesole-serif-headline-extrabold/font.woff2') format('woff2'),
-       url('https://assets.sparkbox.com/fonts/solesole-serif-headline-extrabold/font.woff') format('woff');
+  src: url('https://assets.sparkbox.com/fonts/sole/sole-serif-headline-extrabold/font.woff2') format('woff2'),
+       url('https://assets.sparkbox.com/fonts/sole/sole-serif-headline-extrabold/font.woff') format('woff');
   font-weight: bold;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Sole Sans Serif";
-  src: url('https://assets.sparkbox.com/fonts/solesole-serif-text-light/font.woff2') format('woff2'),
-       url('https://assets.sparkbox.com/fonts/solesole-serif-text-light/font.woff') format('woff');
+  src: url('https://assets.sparkbox.com/fonts/sole/sole-serif-text-light/font.woff2') format('woff2'),
+       url('https://assets.sparkbox.com/fonts/sole/sole-serif-text-light/font.woff') format('woff');
   font-weight: normal;
   font-style: normal;
 }

--- a/src/scss/2020/generic/_fonts.scss
+++ b/src/scss/2020/generic/_fonts.scss
@@ -1,55 +1,24 @@
 @font-face {
   font-family: "Sole Sans";
-    src: url('/fonts/2020/sole-sans-book.woff2') format('woff2'),
-         url('/fonts/2020/sole-sans-book.woff') format('woff');
-    font-weight: 300;
-    font-style: normal;
-}
-
-@font-face {
-font-family: "Sole Sans";
-  src: url('/fonts/2020/sole-sans.woff2') format('woff2'),
-       url('/fonts/2020/sole-sans.woff') format('woff');
-  font-weight: 400;
+  src: url('https://assets.sparkbox.com/fonts/sole/sole-sans-vf-regular-extra-condensed/font.woff2') format('woff2-variations'),
+  url('https://assets.sparkbox.com/fonts/sole/sole-sans-vf-regular-extra-condensed/font.woff') format('woff-variations');
+  font-weight: 300 900;
   font-style: normal;
-}
-
-@font-face {
-font-family: "Sole Sans";
-  src: url('/fonts/2020/sole-sans-semibold.woff2') format('woff2'),
-       url('/fonts/2020/sole-sans-semibold.woff') format('woff');
-  font-weight: 600;
-  font-style: normal;
-}
-
-@font-face {
-    font-family: "Sole Sans";
-    src: url('/fonts/2020/sole-sans-bold.woff2') format('woff2'),
-         url('/fonts/2020/sole-sans-bold.woff') format('woff');
-    font-weight: 700;
-    font-style: normal;
-}
-
-@font-face {
-font-family: "Sole Sans";
-  src: url('/fonts/2020/sole-sans-extrabold.woff2') format('woff2'),
-       url('/fonts/2020/sole-sans-extrabold.woff') format('woff');
-  font-weight: 900;
-  font-style: normal;
+  font-stretch: 100%;
 }
 
 @font-face {
   font-family: "Sole Sans Serif";
-  src: url('/fonts/2020/sole-serif-headline-extrabold.woff2') format('woff2'),
-       url('/fonts/2020/sole-serif-headline-extrabold.woff') format('woff');
+  src: url('https://assets.sparkbox.com/fonts/solesole-serif-headline-extrabold/font.woff2') format('woff2'),
+       url('https://assets.sparkbox.com/fonts/solesole-serif-headline-extrabold/font.woff') format('woff');
   font-weight: bold;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Sole Sans Serif";
-  src: url('/fonts/2020/sole-serif-text-light.woff2') format('woff2'),
-       url('/fonts/2020/sole-serif-text-light.woff') format('woff');
+  src: url('https://assets.sparkbox.com/fonts/solesole-serif-text-light/font.woff2') format('woff2'),
+       url('https://assets.sparkbox.com/fonts/solesole-serif-text-light/font.woff') format('woff');
   font-weight: normal;
   font-style: normal;
 }

--- a/src/scss/2021/generic/_fonts.scss
+++ b/src/scss/2021/generic/_fonts.scss
@@ -7,7 +7,7 @@
 
 @font-face {
   font-family: "Sole Sans";
-  src: url('/fonts/2021/SoleSans.woff2') format('woff2-variations');
+  src: url('https://assets.sparkbox.com/fonts/sole/sole-sans-vf-regular-extra-condensed/font.woff2') format('woff2-variations');
   font-weight: 300 800;
   font-style: normal;
   font-stretch: 130%;


### PR DESCRIPTION
This work updates the 2020 and 2021 pages to load fonts from assets.sparkbox.com instead of locally-hosted.

After this is tested, working, and merged we will scrub the repo of the necessary locally-hosted fonts.

For the Sparkboxer reviewing this PR, it is dependent on this PR: https://github.com/sparkbox/public_assets/pull/6