### PR TITLE
Update install docs for M1 Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Setup
 
 2. Install the ([Gatsby CLI](https://www.gatsbyjs.org/docs/quick-start#install-the-gatsby-cli)) globally `npm install -g gatsby-cli`
 
-3. Run `npm install` to install all packages and dependencies
+3. Run `npm install` to install all packages and dependencies. (If you have a M1 Mac, you may need to run `brew reinstall vips` before installing the site packages and dependencies.)
 
 4. Run `npm start`. This will start a hot-reloading development environment at `localhost:8000`.
 


### PR DESCRIPTION
On my M1 Mac, running `npm install` wasn't completing successfully, and showed the error "Prebuilt libvips binaries not yet available for darwin-arm64v8" -- running `brew reinstall vips` according to https://github.com/lovell/sharp/issues/2460#issuecomment-751491241 worked to install vips natively with all its dependencies on Apple Silicon M1.