### PR TITLE
[7] 2022/responsive fixes

### DIFF
--- a/src/components/2022/circle.js
+++ b/src/components/2022/circle.js
@@ -2,7 +2,7 @@ import React from "react"
 
 const Circle = () => {
   return (
-    <div className="cmp-circle" ariaHidden={true}>
+    <div className="cmp-circle" aria-hidden={true}>
       <div className="cmp-circle__hero-2" />
       <div className="cmp-circle__hero-1" />
     </div>

--- a/src/components/2022/grid-cell.js
+++ b/src/components/2022/grid-cell.js
@@ -10,6 +10,8 @@ const GridCell = (props) => {
   cssProperties['--row-span'] = (props.rowSpan) ? props.rowSpan : null
   cssProperties['--row-start'] = (props.rowStart) ? props.rowStart : null
   cssProperties['--order'] = (props.order) ? props.order : null
+  cssProperties['--position'] = (props.position) ? props.position : null
+  cssProperties['--top'] = (props.top) ? props.top : null
   
   cssProperties['--start-sm'] = (props.startSM) ? props.startSM : null
   cssProperties['--span-sm'] = (props.spanSM) ? props.spanSM : null
@@ -17,6 +19,8 @@ const GridCell = (props) => {
   cssProperties['--row-span-sm'] = (props.rowSpanSM) ? props.rowSpanSM : null
   cssProperties['--row-start-sm'] = (props.rowStartSM) ? props.rowStartSM : null
   cssProperties['--order-sm'] = (props.orderSM) ? props.orderSM : null
+  cssProperties['--position-sm'] = (props.positionSM) ? props.positionSM : null
+  cssProperties['--top-sm'] = (props.topSM) ? props.topSM : null
 
   cssProperties['--start-md'] = (props.startMD) ? props.startMD : null
   cssProperties['--span-md'] = (props.spanMD) ? props.spanMD : null
@@ -24,6 +28,8 @@ const GridCell = (props) => {
   cssProperties['--row-span-md'] = (props.rowSpanMD) ? props.rowSpanMD : null
   cssProperties['--row-start-md'] = (props.rowStartMD) ? props.rowStartMD : null
   cssProperties['--order-md'] = (props.orderMD) ? props.orderMD : null
+  cssProperties['--position-md'] = (props.positionMD) ? props.positionMD : null
+  cssProperties['--top-md'] = (props.topMD) ? props.topMD : null
 
   cssProperties['--start-lg'] = (props.startLG) ? props.startLG : null
   cssProperties['--span-lg'] = (props.spanLG) ? props.spanLG : null
@@ -31,7 +37,9 @@ const GridCell = (props) => {
   cssProperties['--row-span-lg'] = (props.rowSpanLG) ? props.rowSpanLG : null
   cssProperties['--row-start-lg'] = (props.rowStartLG) ? props.rowStartLG : null
   cssProperties['--order-lg'] = (props.orderLG) ? props.orderLG : null
-
+  cssProperties['--position-lg'] = (props.positionLG) ? props.positionLG : null
+  cssProperties['--top-lg'] = (props.topLG) ? props.topLG : null
+  
   return (
     <div className={`obj-grid__col${customClasses}`} style={cssProperties}>
       {props.children}

--- a/src/components/2022/grid-cell.js
+++ b/src/components/2022/grid-cell.js
@@ -4,41 +4,41 @@ import {PropTypes} from "prop-types"
 const GridCell = (props) => {
   let customClasses = (props.className != null) ? ` ${props.className}` : ''
   let cssProperties = {}
-  cssProperties['--start'] = (props.start) ? props.start : null
-  cssProperties['--span'] = (props.span) ? props.span : null
-  cssProperties['--align'] = (props.align) ? props.align : null
-  cssProperties['--row-span'] = (props.rowSpan) ? props.rowSpan : null
-  cssProperties['--row-start'] = (props.rowStart) ? props.rowStart : null
-  cssProperties['--order'] = (props.order) ? props.order : null
-  cssProperties['--position'] = (props.position) ? props.position : null
-  cssProperties['--top'] = (props.top) ? props.top : null
+  cssProperties['--start'] = props.start ?? null
+  cssProperties['--span'] = props.span ?? null
+  cssProperties['--align'] = props.align ?? null
+  cssProperties['--row-span'] = props.rowSpan ?? null
+  cssProperties['--row-start'] = props.rowStart ?? null
+  cssProperties['--order'] = props.order ?? null
+  cssProperties['--position'] = props.position ?? null
+  cssProperties['--top'] = props.top ?? null
   
-  cssProperties['--start-sm'] = (props.startSM) ? props.startSM : null
-  cssProperties['--span-sm'] = (props.spanSM) ? props.spanSM : null
-  cssProperties['--align-sm'] = (props.alignSM) ? props.alignSM : null
-  cssProperties['--row-span-sm'] = (props.rowSpanSM) ? props.rowSpanSM : null
-  cssProperties['--row-start-sm'] = (props.rowStartSM) ? props.rowStartSM : null
-  cssProperties['--order-sm'] = (props.orderSM) ? props.orderSM : null
-  cssProperties['--position-sm'] = (props.positionSM) ? props.positionSM : null
-  cssProperties['--top-sm'] = (props.topSM) ? props.topSM : null
+  cssProperties['--start-sm'] = props.startSM ?? null
+  cssProperties['--span-sm'] = props.spanSM ?? null
+  cssProperties['--align-sm'] = props.alignSM ?? null
+  cssProperties['--row-span-sm'] = props.rowSpanSM ?? null
+  cssProperties['--row-start-sm'] = props.rowStartSM ?? null
+  cssProperties['--order-sm'] = props.orderSM ?? null
+  cssProperties['--position-sm'] = props.positionSM ?? null
+  cssProperties['--top-sm'] = props.topSM ?? null
 
-  cssProperties['--start-md'] = (props.startMD) ? props.startMD : null
-  cssProperties['--span-md'] = (props.spanMD) ? props.spanMD : null
-  cssProperties['--align-md'] = (props.alignMD) ? props.alignMD : null
-  cssProperties['--row-span-md'] = (props.rowSpanMD) ? props.rowSpanMD : null
-  cssProperties['--row-start-md'] = (props.rowStartMD) ? props.rowStartMD : null
-  cssProperties['--order-md'] = (props.orderMD) ? props.orderMD : null
-  cssProperties['--position-md'] = (props.positionMD) ? props.positionMD : null
-  cssProperties['--top-md'] = (props.topMD) ? props.topMD : null
+  cssProperties['--start-md'] = props.startMD ?? null
+  cssProperties['--span-md'] = props.spanMD ?? null
+  cssProperties['--align-md'] = props.alignMD ?? null
+  cssProperties['--row-span-md'] = props.rowSpanMD ?? null
+  cssProperties['--row-start-md'] = props.rowStartMD ?? null
+  cssProperties['--order-md'] = props.orderMD ?? null
+  cssProperties['--position-md'] = props.positionMD ?? null
+  cssProperties['--top-md'] = props.topMD ?? null
 
-  cssProperties['--start-lg'] = (props.startLG) ? props.startLG : null
-  cssProperties['--span-lg'] = (props.spanLG) ? props.spanLG : null
-  cssProperties['--align-lg'] = (props.alignLG) ? props.alignLG : null
-  cssProperties['--row-span-lg'] = (props.rowSpanLG) ? props.rowSpanLG : null
-  cssProperties['--row-start-lg'] = (props.rowStartLG) ? props.rowStartLG : null
-  cssProperties['--order-lg'] = (props.orderLG) ? props.orderLG : null
-  cssProperties['--position-lg'] = (props.positionLG) ? props.positionLG : null
-  cssProperties['--top-lg'] = (props.topLG) ? props.topLG : null
+  cssProperties['--start-lg'] = props.startLG ?? null
+  cssProperties['--span-lg'] = props.spanLG ?? null
+  cssProperties['--align-lg'] = props.alignLG ?? null
+  cssProperties['--row-span-lg'] = props.rowSpanLG ?? null
+  cssProperties['--row-start-lg'] = props.rowStartLG ?? null
+  cssProperties['--order-lg'] = props.orderLG ?? null
+  cssProperties['--position-lg'] = props.positionLG ?? null
+  cssProperties['--top-lg'] = props.topLG ?? null
   
   return (
     <div className={`obj-grid__col${customClasses}`} style={cssProperties}>

--- a/src/components/2022/key-finding.js
+++ b/src/components/2022/key-finding.js
@@ -8,8 +8,8 @@ const KeyFinding = ({ children }) => {
   return (
     <div className="cmp-key-finding">
       <div className="cmp-key-finding__content">
-        <Grid>
-          <GridCell spanLG={10} startLG={2}>
+        <Grid className="util-margin-hrz-md util-margin-hrz-lg@md util-margin-hrz-none@lg">
+          <GridCell spanMD={8} spanLG={10} startLG={2}>
             <h4 className="cmp-key-finding__title">Key Finding</h4>
             <p className="cmp-key-finding__text">{ children }</p>
           </GridCell>

--- a/src/components/2022/layout.js
+++ b/src/components/2022/layout.js
@@ -13,10 +13,8 @@ import "../../js/safe-focus"
 // siteMetadata comes from gatsby-config.js
 const Layout = ({ children }) => {
   return (
-    <div className="obj-page-wrapper">
-      <div className="obj-width-limiter">
-        {children}
-      </div>
+    <div className="obj-width-limiter">
+      {children}
     </div>
   )
 }

--- a/src/components/2022/quote.js
+++ b/src/components/2022/quote.js
@@ -7,8 +7,8 @@ import GridCell from "./grid-cell"
 const Quote = ({ children, source }) => {
   return (
     <blockquote className="cmp-quote">
-      <Grid>
-        <GridCell spanLG={10} startLG={2}>
+      <Grid className="util-margin-hrz-md util-margin-hrz-lg@md util-margin-hrz-none@lg">
+        <GridCell spanMD={8} spanLG={10} startLG={2}>
           <p className="cmp-quote__text">{ children }</p>
           <p className="cmp-quote__source">&ndash; { source}</p>
         </GridCell>

--- a/src/components/2022/related-reading.js
+++ b/src/components/2022/related-reading.js
@@ -9,10 +9,10 @@ const RelatedReading = ({ image, title, description, href }) => {
       <h3 className="cmp-type-body-default util-margin-btm-lg">Related Reading</h3>
       <a className="cmp-related-reading__link" href={href}>
         <Grid gap="lg" gapColMD="1xl">
-          <GridCell spanSM={1} spanMD={2}>
+          <GridCell spanSM={2} spanMD={2}>
             <img src={image} alt="" className="cmp-related-reading__image" />
           </GridCell>
-          <GridCell spanSM={3} startSM={2} spanMD={5} startMD={3} spanLG={6}>
+          <GridCell spanSM={4} startSM={3} spanMD={5} startMD={3} spanLG={6}>
             <h4 className="cmp-type-body-xlarge util-margin-all-none util-weight-regular">{title}<svg className="cmp-related-reading__arrow" width="14" height="16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.703 6.36H1.058v9.16" stroke="currentColor" stroke-width="1.5"/><path d="m7.383 1.52 4.675 4.838-4.675 4.84" stroke="currentColor" stroke-width="1.5"/></svg></h4>
             <p className="cmp-type-body-default util-margin-all-none">{description}</p>
           </GridCell>

--- a/src/components/2022/related-reading.js
+++ b/src/components/2022/related-reading.js
@@ -13,7 +13,7 @@ const RelatedReading = ({ image, title, description, href }) => {
             <img src={image} alt="" className="cmp-related-reading__image" />
           </GridCell>
           <GridCell spanSM={4} startSM={3} spanMD={5} startMD={3} spanLG={6}>
-            <h4 className="cmp-type-body-xlarge util-margin-all-none util-weight-regular">{title}<svg className="cmp-related-reading__arrow" width="14" height="16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.703 6.36H1.058v9.16" stroke="currentColor" stroke-width="1.5"/><path d="m7.383 1.52 4.675 4.838-4.675 4.84" stroke="currentColor" stroke-width="1.5"/></svg></h4>
+            <h4 className="cmp-type-body-xlarge util-margin-all-none util-weight-regular">{title}<svg className="cmp-related-reading__arrow" width="14" height="16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.703 6.36H1.058v9.16" stroke="currentColor" strokeWidth="1.5"/><path d="m7.383 1.52 4.675 4.838-4.675 4.84" stroke="currentColor" strokeWidth="1.5"/></svg></h4>
             <p className="cmp-type-body-default util-margin-all-none">{description}</p>
           </GridCell>
         </Grid>

--- a/src/components/2022/toc-link.js
+++ b/src/components/2022/toc-link.js
@@ -4,7 +4,7 @@ import AnchorLink from "react-anchor-link-smooth-scroll"
 
 const DownArrow = () => {
   return (
-    <svg className="cmp-toc-link__arrow" width="24" height="22" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg"><path d="M14.768 19.42V1.656H0"/><path d="m22.57 12.213-7.802 7.8-7.8-7.8" /></svg>
+    <svg className="cmp-toc-link__arrow" width="24" height="22" fill="none" stroke="currentColor" strokeWidth="1.5" xmlns="http://www.w3.org/2000/svg"><path d="M14.768 19.42V1.656H0"/><path d="m22.57 12.213-7.802 7.8-7.8-7.8" /></svg>
   )
 }
 
@@ -20,7 +20,7 @@ const TOCLink = ({ to, text }) => {
   const content = text.replace(last, '');
   return (
     <AnchorLink className="cmp-toc-link" href={`#section-${to}`}>
-      <span className="cmp-toc-link__number" ariaLabel={`Section ${to}`}>0{to}</span>
+      <span className="cmp-toc-link__number" aria-label={`Section ${to}`}>0{to}</span>
       <span className="cmp-toc-link__text">{content}</span>
       <span className="cmp-toc-link__last"><span className="cmp-toc-link__text">{last}</span><DownArrow /></span>
     </AnchorLink>

--- a/src/components/2022/toc-link.js
+++ b/src/components/2022/toc-link.js
@@ -2,12 +2,27 @@ import React from "react"
 import PropTypes from "prop-types"
 import AnchorLink from "react-anchor-link-smooth-scroll"
 
+const DownArrow = () => {
+  return (
+    <svg className="cmp-toc-link__arrow" width="24" height="22" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg"><path d="M14.768 19.42V1.656H0"/><path d="m22.57 12.213-7.802 7.8-7.8-7.8" /></svg>
+  )
+}
+
 const TOCLink = ({ to, text }) => {
+  // These variables split apart the link text,
+  // removes the last unbroken character string,
+  // then combines that last string with the 
+  // down arrow in order to prevent the arrow
+  // from being alone on a line below the text.
+  const words = text.split(' ');
+  const count = words.length;
+  const last = words[count - 1];
+  const content = text.replace(last, '');
   return (
     <AnchorLink className="cmp-toc-link" href={`#section-${to}`}>
       <span className="cmp-toc-link__number" ariaLabel={`Section ${to}`}>0{to}</span>
-      <span className="cmp-toc-link__text">{text}</span>
-      <svg className="cmp-toc-link__arrow" width="24" height="22" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg"><path d="M14.768 19.42V1.656H0"/><path d="m22.57 12.213-7.802 7.8-7.8-7.8" /></svg>
+      <span className="cmp-toc-link__text">{content}</span>
+      <span className="cmp-toc-link__last"><span className="cmp-toc-link__text">{last}</span><DownArrow /></span>
     </AnchorLink>
   )
 }

--- a/src/scss/2022/components/_gauge.scss
+++ b/src/scss/2022/components/_gauge.scss
@@ -1,3 +1,4 @@
+@use "../tools/media-queries" as *;
 @use "../tools/typography";
 @use "../tools/fills";
 @use "../tools/color";
@@ -33,8 +34,12 @@
         var(--color-gray) var(--deg),
         transparent var(--deg)) no-repeat,
       fills.dots(color.alpha('gray', 0.8), 6, 0.5) repeat fixed;
-    mask-image: img.svg('<svg height="10" width="10" viewBox="0 0 10 10" fill="none"><circle cx="5" cy="5" stroke="#000" vector-effect="non-scaling-stroke" stroke-width="16" r="4.5" /></svg>');
+    mask-image: img.svg('<svg height="10" width="10" viewBox="0 0 10 10" fill="none"><circle cx="5" cy="5" stroke="#000" vector-effect="non-scaling-stroke" stroke-width="10" r="4.5" /></svg>');
     mask-size: contain;
+    
+    @media(min-width: mq(sm)) {
+      mask-image: img.svg('<svg height="10" width="10" viewBox="0 0 10 10" fill="none"><circle cx="5" cy="5" stroke="#000" vector-effect="non-scaling-stroke" stroke-width="16" r="4.5" /></svg>');
+    }
   }
   
   &__percent {

--- a/src/scss/2022/components/_hero.scss
+++ b/src/scss/2022/components/_hero.scss
@@ -27,7 +27,7 @@
     // Allows the font to be fluid in relation to the hero size
     font-size: min(12vw, calc(var(--hero-max-width) * 0.12));
     
-    @media (min-width: mq(sm)) {
+    @media (min-width: mq(lg)) {
       font-size: min(14vw, calc(var(--hero-max-width) * 0.14));
     }
 
@@ -63,7 +63,7 @@
     
     font-size: min(20vw, calc(var(--hero-max-width) * 0.2));
     
-    @media (min-width: mq(sm)) {
+    @media (min-width: mq(lg)) {
       font-size: min(24vw, calc(var(--hero-max-width) * 0.24));
     }
   }

--- a/src/scss/2022/components/_hero.scss
+++ b/src/scss/2022/components/_hero.scss
@@ -1,5 +1,6 @@
 @use "../tools/svg" as *;
 @use "../tools/color" as *;
+@use "../tools/media-queries" as *;
 
 .cmp-hero {
   margin: 0 auto;
@@ -24,7 +25,11 @@
     font-family: var(--font-display);
     grid-area: b;
     // Allows the font to be fluid in relation to the hero size
-    font-size: min(14vw, calc(var(--hero-max-width) * 0.14));
+    font-size: min(12vw, calc(var(--hero-max-width) * 0.12));
+    
+    @media (min-width: mq(sm)) {
+      font-size: min(14vw, calc(var(--hero-max-width) * 0.14));
+    }
 
     &::after {
       z-index: 300;
@@ -49,25 +54,32 @@
     font-weight: 100;
     font-stretch: 80%;
     // Allows the font to be fluid in relation to the hero size
-    font-size: min(24vw, calc(var(--hero-max-width) * 0.24));
     text-align: right;
     grid-area: d;
     align-self: end;
     color: var(--color-gray);
     position: relative;
     z-index: 200;
+    
+    font-size: min(20vw, calc(var(--hero-max-width) * 0.2));
+    
+    @media (min-width: mq(sm)) {
+      font-size: min(24vw, calc(var(--hero-max-width) * 0.24));
+    }
   }
 
   &__edition {
     font-weight: 200;
     // Allows the font to be fluid in relation to the hero size
-    font-size: min(25vw, calc(var(--hero-max-width) * 0.025));
+    font-size: min(5vw, calc(var(--hero-max-width) * 0.025));
     grid-area: c;
     align-self: center;
     color: var(--color-gray);
   }
   
   &__logo {
+    width: 40vw;
+    max-width: 11.875rem;
     justify-self: end;
     grid-area: a;
   }

--- a/src/scss/2022/components/_key-finding.scss
+++ b/src/scss/2022/components/_key-finding.scss
@@ -16,7 +16,7 @@
   }
   
   &::before {
-    inset: #{space('lg') * -1};
+    inset: -1.5rem;
     background: fills.dots(color.alpha('gray', 0.8), 6, 0.5) repeat fixed;
     z-index: var(--z1);
   }

--- a/src/scss/2022/components/_number.scss
+++ b/src/scss/2022/components/_number.scss
@@ -2,9 +2,9 @@
 
 .cmp-number {
   border-top: 1px solid currentcolor;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-gap: 0.5rem;
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-lg);
 
   &--small {
     padding: 1rem 0;

--- a/src/scss/2022/components/_section-header.scss
+++ b/src/scss/2022/components/_section-header.scss
@@ -2,6 +2,7 @@
 @use "../tools/svg" as *;
 @use "../tools/color" as *;
 @use "../tools/space" as *;
+@use "../tools/media-queries" as *;
 
 .section-header {
   padding: space('10vh') var(--space-limiter-margin);
@@ -10,10 +11,11 @@
   overflow: hidden;
   
   &::after {
+    --max-size: 26rem;
     content: '';
     display: block;
-    height: min(40vmin, 26rem);
-    width: min(40vmin, 26rem);
+    height: min(40vmin, var(--max-size));
+    width: min(40vmin, var(--max-size));
     border: 1px solid hsla(var(--color-pink-1-val), 0.3);
     background: radial-gradient(circle at 200% 50%,
                                 hsla(var(--color-pink-1-val), 0.5) 0%, 40%,
@@ -25,8 +27,8 @@
                                 #000f 60%,
                                 #0000 95%);
     position: absolute;
-    top: calc(10vh + 12rem);
-    left: calc(50% + 6rem);
+    top: calc(10vh + (var(--max-size) / 2));
+    left: calc(50% + (var(--max-size) / 5));
     transform: rotate(-45deg);
     transform-origin: top left;
     pointer-events: none;
@@ -37,23 +39,24 @@
     @include typography.style('heading-1');
     line-height: 1;
     position: relative;
-    padding-top: 3.5rem;
-    padding-left: 5rem;
+    padding-top: var(--space-1xp);
+    min-height: var(--space-2xl);
+    display: grid;
+    grid-template-columns: minmax(3rem, max-content) auto;
+    align-items: end;
+    gap: var(--space-sm);
 
     &::before {
       pointer-events: none;
       font-family: var(--font-text);
       @include typography.number('small');
       content: '0' attr(data-number);
-      position: absolute;
-      top: 0;
-      left: 0;
+      align-self: stretch; // stretches item within the parent grid
       display: inline-flex;
       place-items: start;
-      height: 8rem;
-      width: 6rem;
+      padding-right: 2em; // scales the padding the fluid font size
       color: var(--color-gray);
-      background: svg('<svg width="290" height="439"><path d="m287 2.327-284 435" stroke="#{color(dark)}" stroke-width="5"/></svg>') no-repeat center / contain;
+      background: svg('<svg width="290" height="439"><path d="m287 2.327-284 435" stroke="#{color(dark)}" stroke-width="5"/></svg>') no-repeat top right / contain;
     }
   }
   

--- a/src/scss/2022/components/_section-header.scss
+++ b/src/scss/2022/components/_section-header.scss
@@ -4,8 +4,10 @@
 @use "../tools/space" as *;
 
 .section-header {
-  padding: space('10vh') 0;
+  padding: space('10vh') var(--space-limiter-margin);
+  margin: 0 calc(var(--space-limiter-margin) * -1);
   position: relative;
+  overflow: hidden;
   
   &::after {
     content: '';

--- a/src/scss/2022/components/_toc-link.scss
+++ b/src/scss/2022/components/_toc-link.scss
@@ -24,6 +24,11 @@
     color: var(--color-white);
     transition: border-bottom-color var(--default-duration) var(--default-timing);
   }
+  
+  &__last {
+    display: inline-block;
+    white-space: nowrap;
+  }
 
   &__arrow {
     transform: translate(0.25rem, 0.125rem);

--- a/src/scss/2022/generic/_normalize.scss
+++ b/src/scss/2022/generic/_normalize.scss
@@ -44,6 +44,6 @@ textarea {
   overflow: auto;
 }
 
-img {
+img, svg {
   max-width: 100%;
 }

--- a/src/scss/2022/objects/_grid.scss
+++ b/src/scss/2022/objects/_grid.scss
@@ -1,7 +1,7 @@
 @use "../tools/media-queries" as *;
 
 .obj-grid {
-  --grid-size: 4;
+  --grid-size: 6;
 
   // Default
   --gap: initial;
@@ -30,7 +30,7 @@
   column-gap: var(--gap-col, var(--gap));
   
   @media (min-width: mq('sm')) {
-    --grid-size: 4;
+    --grid-size: 6;
     row-gap: var(--gap-row-sm, var(--gap-sm));
     column-gap: var(--gap-col-sm, var(--gap-sm));
   }
@@ -50,11 +50,13 @@
   &__col {
     // Default
     --start: 1;
-    --span: 4;
-    --align: 'top';
+    --span: 6;
+    --align: start;
     --row-span: 1;
     --row-start: auto;
     --order: auto;
+    --position: unset;
+    --top: 0;
 
     // Default @SM
     --start-sm: var(--start);
@@ -63,6 +65,8 @@
     --row-span-sm: var(--row-span);
     --row-start-sm: var(--row-start);
     --order-sm: var(--order);
+    --position-sm: var(--position);
+    --top-sm: var(--top);
 
     // Default @MD
     --start-md: var(--start-sm);
@@ -71,6 +75,8 @@
     --row-span-md: var(--row-span-sm);
     --row-start-md: var(--row-start-sm);
     --order-md: var(--order-sm);
+    --position-md: var(--position-sm);
+    --top-md: var(--top-sm);
 
     // Default @LG
     --start-lg: var(--start-md);
@@ -79,17 +85,23 @@
     --row-span-lg: var(--row-span-md);
     --row-start-lg: var(--row-start-md);
     --order-lg: var(--order-md);
+    --position-lg: var(--position-md);
+    --top-lg: var(--top-md);
 
     grid-column: var(--start) / span var(--span);
     grid-row: var(--row-start) / span var(--row-span);
     align-self: var(--align);
     order: var(--order);
+    position: var(--position);
+    top: var(--top);
     
     @media (min-width: mq('sm')) {
       grid-column: var(--start-sm) / span var(--span-sm);
       grid-row: var(--row-start-sm) / span var(--row-span-sm);
       align-self: var(--align-sm);
       order: var(--order-sm);
+      position: var(--position-sm);
+      top: var(--top-sm);
     }
 
     @media (min-width: mq('md')) {
@@ -97,6 +109,8 @@
       grid-row: var(--row-start-md) / span var(--row-span-md);
       align-self: var(--align-md);
       order: var(--order-md);
+      position: var(--position-md);
+      top: var(--top-md);
     }
     
     @media (min-width: mq('lg')) {
@@ -104,6 +118,8 @@
       grid-row: var(--row-start-lg) / span var(--row-span-lg);
       align-self: var(--align-lg);
       order: var(--order-lg);
+      position: var(--position-lg);
+      top: var(--top-lg);
     }
   }
 }

--- a/src/scss/2022/objects/_limiters.scss
+++ b/src/scss/2022/objects/_limiters.scss
@@ -1,9 +1,5 @@
-.obj-page-wrapper {
-  overflow: hidden;
-}
-
 .obj-width-limiter {
-  width: min(calc(100% - 3rem), var(--max-width));
+  width: min(calc(100% - (var(--space-limiter-margin) * 2)), var(--max-width));
   margin: 0 auto;
 }
 

--- a/src/scss/2022/settings/_font-size.scss
+++ b/src/scss/2022/settings/_font-size.scss
@@ -1,18 +1,18 @@
 $sizes: (
-  'heading-1': 4.5rem,
-  'heading-2': 3.5rem,
-  'heading-3': 2.5rem,
-  'heading-4': 2rem,
-  'section-description': 1.75rem,
-  'body-xlarge': 1.5rem,
-  'body-large': 1.25rem,
+  'heading-1': clamp( 2rem, 5vw, 4.5rem),
+  'heading-2': clamp( 1.75rem, 5vw, 3.5rem),
+  'heading-3': clamp( 1.625rem, 5vw, 2.5rem),
+  'heading-4': clamp( 1.5rem, 5vw, 2rem),
+  'section-description': clamp( 1.375rem, 5vw, 1.75rem),
+  'body-xlarge': clamp( 1.25rem, 5vw, 1.5rem),
+  'body-large': clamp( 1.125rem, 5vw, 1.25rem),
   'body-default': 1.0625rem,
   'caption': 0.875rem
 );
 
 $numbers: (
-  'small': 1.875rem,
-  'medium': 2.625rem,
-  'large': 5rem,
-  'xlarge': 10.625rem
+  'small': clamp(1.25rem, 5vw, 1.875rem),
+  'medium': clamp(1.5rem, 5vw, 2.625rem),
+  'large': clamp(1.75rem, 5vw, 5rem),
+  'xlarge': min(20vw, 10.625rem)
 );

--- a/src/scss/2022/settings/_font-size.scss
+++ b/src/scss/2022/settings/_font-size.scss
@@ -1,9 +1,9 @@
 $sizes: (
   'heading-1': clamp( 2rem, 5vw, 4.5rem),
-  'heading-2': clamp( 1.75rem, 5vw, 3.5rem),
-  'heading-3': clamp( 1.625rem, 5vw, 2.5rem),
-  'heading-4': clamp( 1.5rem, 5vw, 2rem),
-  'section-description': clamp( 1.375rem, 5vw, 1.75rem),
+  'heading-2': clamp( 1.625rem, 5vw, 3.5rem),
+  'heading-3': clamp( 1.5rem, 5vw, 2.5rem),
+  'heading-4': clamp( 1.25rem, 5vw, 2rem),
+  'section-description': clamp( 1.125rem, 5vw, 1.75rem),
   'body-xlarge': clamp( 1.25rem, 5vw, 1.5rem),
   'body-large': clamp( 1.125rem, 5vw, 1.25rem),
   'body-default': 1.0625rem,

--- a/src/scss/2022/settings/_root.scss
+++ b/src/scss/2022/settings/_root.scss
@@ -29,6 +29,8 @@
     --space-#{$key}: #{$value};
   }
   
+  --space-limiter-margin: 1.5rem;
+  
   --default-duration: 150ms;
   --default-timing: ease-in-out;
   

--- a/src/sections/2022/intro.mdx
+++ b/src/sections/2022/intro.mdx
@@ -2,7 +2,7 @@ import Grid from "../../components/2022/grid"
 import GridCell from "../../components/2022/grid-cell"
 
 <Grid className="util-margin-vrt-20vh">
-  <GridCell spanLG="9">
+  <GridCell spanMD={7} spanLG={9}>
     <p class="cmp-type-section-description">Every year, we are surprised by what we learn from the perspectives of people who work with design systems day in and day out. This year, we took particular interest in learning from both the people building and maintaining a design system and those who use or contribute to it in addition to their other responsibilities. Over 200 web professionals responded with their experiences. Read on for this year’s findings.</p>
   </GridCell>
 </Grid>

--- a/src/sections/2022/section-1.mdx
+++ b/src/sections/2022/section-1.mdx
@@ -16,25 +16,26 @@ import Number from "../../components/2022/number"
     </GridCell>
   </Grid>
   <Grid gap="lg" gapColMD="none">
-    <GridCell spanSM={2} spanMD={4} spanLG={3}>
+    <GridCell spanSM={3} spanMD={4} spanLG={3}>
       <Number title="Design / User Experience" number="58%" />
     </GridCell>
-    <GridCell spanSM={2} spanMD={4} spanLG={3} startSM={3} startMD={1} startLG={5}>
+    <GridCell spanSM={3} spanMD={4} spanLG={3} startSM={4} startMD={1} startLG={5}>
       <Number title="Development" number="19%" />
     </GridCell>
-    <GridCell spanSM={2} spanMD={4} spanLG={3}>
+    <GridCell spanSM={3} spanMD={4} spanLG={3}>
       <Number title="Management / Leadership" number="15%" />
     </GridCell>
-    <GridCell spanSM={2} spanMD={4} spanLG={3} startSM={3} startMD={1} startLG={5}>
+    <GridCell spanSM={3} spanMD={4} spanLG={3} startSM={4} startMD={1} startLG={5}>
       <Number title="Project / Product Management" number="5%" />
     </GridCell>
-    <GridCell spanSM={2} spanMD={4} spanLG={3}>
+    <GridCell spanSM={3} spanMD={4} spanLG={3}>
       <Number title="Other" number="3%" />
     </GridCell>
-    <GridCell spanMD={3} startMD={6} startLG={9} rowStartMD={-1} rowSpanMD={6} rowSpanLG={4}>
+    <GridCell spanMD={3} startMD={6} startLG={9} rowStartMD={-1} rowSpanMD={6} rowSpanLG={5} positionMD="sticky" topMD="10vh" positionLG="unset">
       <p class="util-margin-all-none cmp-type-body-default">Our survey respondents represented more than 20 industry categories, including financial services, telecommunications, IT hardware and software, healthcare and pharmaceuticals, government, manufacturing, education, and retail.</p>
     </GridCell>
-    
+  </Grid>
+  <Grid>
     <GridCell spanLG="6">
       <p class="cmp-type-caption">We shared this survey for 4 weeks across our social media network, in Slack channels, with visitors to the Sparkbox website, and in emails to web professionals.</p>
     </GridCell>

--- a/src/sections/2022/section-2.mdx
+++ b/src/sections/2022/section-2.mdx
@@ -15,58 +15,58 @@ import Quote from "../../components/2022/quote"
   </SectionHeader>
   
   <Grid gap="lg" gapColMD="1xl" gapColLG="none">
-    <GridCell spanSM={2} spanMD={4} spanLG={3}>
+    <GridCell spanSM={3} spanMD={4} spanLG={3}>
       <Number title="Typefaces, colors, and&nbsp;styles" number="98%" />
     </GridCell>
-    <GridCell spanSM={2} spanMD={4} spanLG={3} startSM={3} startMD={5} startLG={5}>
+    <GridCell spanSM={3} spanMD={4} spanLG={3} startSM={4} startMD={5} startLG={5}>
       <Number title="Components" number="95%" />
     </GridCell>
-    <GridCell spanSM={2} spanMD={4} spanLG={3} startLG={9}>
+    <GridCell spanSM={3} spanMD={4} spanLG={3} startLG={9}>
       <Number title="Component Documentation" number="85%" />
     </GridCell>
     
-    <GridCell spanSM={2} spanMD={4} spanLG={3} startSM={3} startMD={5} startLG={1}>
+    <GridCell spanSM={3} spanMD={4} spanLG={3} startSM={4} startMD={5} startLG={1}>
       <Number title="Designer-ready assets" number="75%" />
     </GridCell>
-    <GridCell spanSM={2} spanMD={4} spanLG={3} startSM={1} startMD={1} startLG={5}>
+    <GridCell spanSM={3} spanMD={4} spanLG={3} startSM={1} startMD={1} startLG={5}>
       <Number title="Grid/layout systems" number="71%" />
     </GridCell>
-    <GridCell spanSM={2} spanMD={4} spanLG={3} startSM={3} startMD={5} startLG={9}>
+    <GridCell spanSM={3} spanMD={4} spanLG={3} startSM={4} startMD={5} startLG={9}>
       <Number title="Design tokens" number="69%" />
     </GridCell>
     
-    <GridCell spanSM={2} spanMD={4} spanLG={3} startMD={1} startLG={1}>
+    <GridCell spanSM={3} spanMD={4} spanLG={3} startMD={1} startLG={1}>
       <Number title="Developer-ready code" number="65%" />
     </GridCell>
-    <GridCell spanSM={2} spanMD={4} spanLG={3} startSM={3} startMD={5} startLG={5}>
+    <GridCell spanSM={3} spanMD={4} spanLG={3} startSM={4} startMD={5} startLG={5}>
       <Number title="Accessibility Guidelines" number="57%" />
     </GridCell>
   </Grid>
   
   <Grid className="util-margin-top-1xl">
-    <GridCell spanLG={9}>
+    <GridCell spanMD={7} spanLG={9}>
       <h3>What’s more interesting is what they “didn’t” have in their design systems.</h3>
     </GridCell>
   </Grid>
-  <Grid className="util-margin-top-1xl" gapRow="2xl">
-    <GridCell spanLG={3}>
+  <Grid className="util-margin-top-1xl" gapRowMD="2xl" gap="lg">
+    <GridCell spanSM={3} spanMD={2} spanLG={3} rowSpanMD={2} positionMD="sticky" topMD="10vh">
       <p>Fewer than 50% of respondents reported having content guidelines, experience design principles, or release information.</p>
       <p>And fewer than 35% have playgrounds to experiment with code or animation guidance.</p>
       <p class="cmp-type-caption">Respondents: 219 Respondents were asked to select all that applied.</p>
     </GridCell>
-    <GridCell span={2} startLG={5}>
+    <GridCell span={4} start={2} spanSM={3} startSM={4} spanMD={2} startMD={3} startLG={5}>
       <Gauge title="Content Guidelines" number={45} />
     </GridCell>
-    <GridCell span={2}  startLG={8}>
+    <GridCell span={4} start={2} spanSM={3} startSM={1} spanMD={2} startMD={5} startLG={8}>
       <Gauge title="Experience Design Principles" number={42} />
     </GridCell>
-    <GridCell span={2}  startLG={11}>
+    <GridCell span={4} start={2} spanSM={3} startSM={4} spanMD={2} startMD={7} startLG={11}>
       <Gauge title="Release Information" number={41} />
     </GridCell>
-    <GridCell span={2} startLG={5}>
-      <Gauge title="Playground to Experiment&nbsp;with&nbsp;Code" number={34} />
+    <GridCell span={4} start={2} spanSM={3} startSM={1} spanMD={2} startMD={3} startLG={5}>
+      <Gauge title="Playground to Experiment with&nbsp;Code" number={34} />
     </GridCell>
-    <GridCell span={2} startLG={8}>
+    <GridCell span={4} start={2} spanSM={3} startSM={4} startMD={5} spanMD={2} startLG={8}>
       <Gauge title="Animation Guidelines" number={19} />
     </GridCell>
   </Grid>
@@ -74,7 +74,7 @@ import Quote from "../../components/2022/quote"
   <RelatedReading title="The Anatomy of a Design System" description="A design system should have certain fundamental pieces in order to be successful. But what are those pieces?" image="https://sparkbox.com/uploads/featured_images/b-callahan_22-04.png" href="https://sparkbox.com/foundry/design_system_makeup_design_system_layers_parts_of_a_design_system" />
     
   <Grid>
-    <GridCell spanLG={9}>
+    <GridCell spanMD={7} spanLG={9}>
       <p class="cmp-type-heading-4">We were also curious about what established processes and practices were in place for our respondent’s design systems. We found that 61% of respondents had processes for subscribers to contribute to the design system. Just 44% had governance models or shared the product roadmap for the design system. And only 16% tracked metrics&mdash;which is consistent with last year’s survey results.</p>
     </GridCell>
   </Grid>
@@ -84,19 +84,19 @@ import Quote from "../../components/2022/quote"
   <Quote source="Design System Maintainer">[Our design system] has completely revolutionized how we collaborate with other teams and document and present our brand. Now, we can't imagine operating any other way.</Quote>
 
   <Grid gap="lg" gapColMD="1xl" gapColLG="none">
-    <GridCell spanLG={9}>
+    <GridCell spanMD={7} spanLG={9}>
       <h3>Respondents who felt their design system was successful had established processes and practices in place.</h3>
     </GridCell>
-    <GridCell span={2}>
+    <GridCell span={4} start={2} spanSM={3} startSM={1} startMD={2} startLG={1} spanLG={2}>
       <Gauge title="Onboarding new subscribers and/or contributors" number={84} />
     </GridCell>
-    <GridCell span={2} startLG={4}>
+    <GridCell span={4} start={2} spanSM={3} startSM={4} startMD={5} startLG={4} spanLG={2}>
       <Gauge title="Determining what to add, update, or remove" number={78} />
     </GridCell>
-    <GridCell span={2} startLG={7}>
+    <GridCell span={4} start={2} spanSM={3} startSM={1} startMD={2} startLG={7} spanLG={2}>
       <Gauge title="Contributing" number={76} />
     </GridCell>
-    <GridCell span={2}  startLG={10}>
+    <GridCell span={4} start={2} spanSM={3} startSM={4} startMD={5} startLG={10} spanLG={2}>
       <Gauge title="Training and Support" number={76} />
     </GridCell>
   </Grid>

--- a/src/sections/2022/section-3.mdx
+++ b/src/sections/2022/section-3.mdx
@@ -17,25 +17,25 @@ import Quote from "../../components/2022/quote"
   <div>PIE CHART</div>
 
   <Grid className="util-margin-top-1xl">
-    <GridCell spanLG={9}>
+    <GridCell spanMD={7} spanLG={9}>
       <h3>The subscribers who felt their needs are met also reported their design systems have established:</h3>
     </GridCell>
   </Grid>
 
-  <Grid className="util-margin-top-1xl" gapRow="md">
-    <GridCell span={2}>
+  <Grid className="util-margin-top-1xl" gap="lg" gapColMD="1xl" gapColLG="none">
+    <GridCell span={4} start={2} spanSM={3} spanLG={2} startSM={1} startMD={2} startLG={1}>
       <Gauge title="Processes for determining what to add, update, or remove" number={86} />
     </GridCell>
-    <GridCell span={2} startLG={4}>
+    <GridCell span={4} start={2} spanSM={3} spanLG={2} startSM={4} startMD={5} startLG={4}>
       <Gauge title="Onboarding new subscribers and/or contributors" number={83} />
     </GridCell>
-    <GridCell span={2} startLG={7}>
+    <GridCell span={4} start={2} spanSM={3} spanLG={2} startSM={1} startMD={2} startLG={7}>
       <Gauge title="Support and training" number={75} />
     </GridCell>
-    <GridCell span={2} startLG={10}>
+    <GridCell span={6} start={1} spanSM={3} spanLG={3} startSM={4} startMD={5} startLG={10} align="center" alignLG="start">
       <p>In addition, 67% of these satisfied subscribers reported that their design system was the source of truth for how things should be done and 85% felt supported by the design system maintainers.</p>
     </GridCell>
-    <GridCell>
+    <GridCell startMD={2} startLG={1}>
       <p class="cmp-type-caption">Responses: 29</p>
     </GridCell>
   </Grid>
@@ -43,52 +43,52 @@ import Quote from "../../components/2022/quote"
   <KeyFinding>84% of all subscriber respondents said they are required to use the design system for their work.</KeyFinding>
 
  <Grid className="util-margin-top-1xl">
-    <GridCell spanLG={9}>
+    <GridCell spanMD={7} spanLG={9}>
       <h3>What challenges do you face when you use the design system?</h3>
     </GridCell>
   </Grid>
   
-  <Grid className="util-margin-top-1xl" gapRow="md">
-    <GridCell span={3}>
+  <Grid className="util-margin-top-1xl" gapRow="lg" gapColMD="1xl" gapColLG="none">
+    <GridCell span={6} spanMD={4} spanLG={3} rowSpanMD={2} rowSpanLG={1} topMD="20vh" positionMD="sticky" positionLG="unset">
       <p>The top challenges subscribers reported were poor documentation and not being able to tell what Is old, broken, or coming soon.</p>
       <p>Respondents also reported other challenges like poor organization and the system not having what they need. There's an opportunity to invest in a better user experience for design system subscribers.</p>
     </GridCell>
-    <GridCell span={3} startLG={5}>
+    <GridCell span={4} start={2} startMD={5} startLG={5} spanLG={3}>
       <Gauge title="It's Documented Poorly" number={39} size="large" />
     </GridCell>
-    <GridCell span={3} startLG={9}>
+    <GridCell span={4} start={2} startMD={5} startLG={9} spanLG={3}>
       <Gauge title="It's unclear what is old, broken, or&nbsp;coming&nbsp;soon" number={35} size="large" />
     </GridCell>
   </Grid>
   
   <Grid gap="lg" gapColMD="1xl" gapColLG="none" className="util-margin-top-10vh">
-    <GridCell spanSM={2} spanMD={4} spanLG={3}>
+    <GridCell spanSM={3} spanMD={4} spanLG={3}>
       <Number title="It doesn’t have what I need" number="26%" />
     </GridCell>
-    <GridCell spanSM={2} spanMD={4} spanLG={3} startSM={3} startMD={5} startLG={5}>
+    <GridCell spanSM={3} spanMD={4} spanLG={3} startSM={4} startMD={5} startLG={5}>
       <Number title="Components" number="26%" />
     </GridCell>
-    <GridCell spanSM={2} spanMD={4} spanLG={3} startLG={9}>
+    <GridCell spanSM={3} spanMD={4} spanLG={3} startLG={9}>
       <Number title="Component Documentation" number="19%" />
     </GridCell>
     
-    <GridCell spanSM={2} spanMD={4} spanLG={3} startSM={3} startMD={5} startLG={1}>
+    <GridCell spanSM={3} spanMD={4} spanLG={3} startSM={4} startMD={5} startLG={1}>
       <Number title="Designer-ready assets" number="19%" />
     </GridCell>
-    <GridCell spanSM={2} spanMD={4} spanLG={3} startSM={1} startMD={1} startLG={5}>
+    <GridCell spanSM={3} spanMD={4} spanLG={3} startSM={1} startMD={1} startLG={5}>
       <Number title="Grid/layout systems" number="16%" />
     </GridCell>
-    <GridCell spanSM={2} spanMD={4} spanLG={3} startSM={3} startMD={5} startLG={9}>
+    <GridCell spanSM={3} spanMD={4} spanLG={3} startSM={4} startMD={5} startLG={9}>
       <Number title="Design tokens" number="13%" />
     </GridCell>
     
-    <GridCell spanSM={2} spanMD={4} spanLG={3} startMD={1} startLG={1}>
+    <GridCell spanSM={3} spanMD={4} spanLG={3} startMD={1} startLG={1}>
       <Number title="Developer-ready code" number="13%" />
     </GridCell>
-    <GridCell spanSM={2} spanMD={4} spanLG={3} startSM={3} startMD={5} startLG={5}>
+    <GridCell spanSM={3} spanMD={4} spanLG={3} startSM={4} startMD={5} startLG={5}>
       <Number title="Accessibility Guidelines" number="13%" />
     </GridCell>
-    <GridCell spanSM={2} spanMD={4} spanLG={3} startSM={3} startMD={5} startLG={9}>
+    <GridCell spanSM={3} spanMD={4} spanLG={3} startSM={1} startLG={9}>
       <Number title="Design tokens" number="3%" />
     </GridCell>
     <GridCell>

--- a/src/sections/2022/section-4.mdx
+++ b/src/sections/2022/section-4.mdx
@@ -12,34 +12,42 @@ import Quote from "../../components/2022/quote"
     <p>We heard from 162 respondents who said they maintained design systems. We wanted to learn what their top challenges and priorities were this year.</p>
   </SectionHeader>
   
-  <Grid className="util-margin-top-1xl" gapRow="md">
-    <GridCell span={3} rowSpanMD={3}>
+  <Grid className="util-margin-top-1xl" gap="lg" gapColLG="none">
+    <GridCell span={3} spanMD={2} rowSpanMD={3} spanLG={3}>
       <p className="cmp-type-body-default util-margin-top-none">As reported by respondents who create or maintain design systems, the top five challenges facing design systems are:</p>
     </GridCell>
-    <GridCell span={3} startLG={5}>
+    <GridCell span={3} startMD={4} startMD={3} startLG={5}>
       <Number title="Overcoming technical / creative&nbsp;debt" number={1} />
     </GridCell>
-    <GridCell span={3} startLG={9}>
+    <GridCell span={3} startSM={4} startMD={6} startLG={9}>
       <Number title="Parity between design and code" number={2} />
     </GridCell>
-    <GridCell span={3} startLG={5}>
+    <GridCell span={3} startMD={3} startLG={5}>
       <Number title="Adoption" number={3} />
     </GridCell>
-    <GridCell span={3} startLG={9}>
+    <GridCell span={3} startSM={4} startMD={6} startLG={9}>
       <Number title="Staffing" number={4} />
     </GridCell>
-    <GridCell span={3} startLG={5}>
+    <GridCell span={3} startMD={3} startLG={5}>
       <Number title="Expanding the design system" number={5} />
     </GridCell>
   </Grid>
   
   <Quote source="Design System Maintainer">We believe in our design system. It is not perfect and not perfectly used, but we all want to make it better and can all contribute.</Quote>
 
-  <h3>What are the top two challenges for the design system at this moment?</h3>
+  <Grid>
+    <GridCell spanMD={7} spanLG={9}>
+      <h3>What are the top two challenges for the design system at this moment?</h3>
+    </GridCell>
+  </Grid>
 
   <p>COMPARISON CHART</p>
-  
-  <p className="cmp-type-heading-3">With the exception of staffing, these top challenges were the same as their top priorities. But how can teams overcome these challenges without adequate staffing? When we looked at maintainers who said their design systems were successful, they were more likely to have staffing as one of their top priorities.</p>
+
+  <Grid>
+    <GridCell spanMD={7} spanLG={9}>
+      <p className="cmp-type-heading-3">With the exception of staffing, these top challenges were the same as their top priorities. But how can teams overcome these challenges without adequate staffing? When we looked at maintainers who said their design systems were successful, they were more likely to have staffing as one of their top priorities.</p>
+    </GridCell>
+  </Grid>
 
   <RelatedReading
     title="Why Your Design System Needs a Documentation Site"

--- a/src/sections/2022/section-4.mdx
+++ b/src/sections/2022/section-4.mdx
@@ -13,22 +13,22 @@ import Quote from "../../components/2022/quote"
   </SectionHeader>
   
   <Grid className="util-margin-top-1xl" gap="lg" gapColLG="none">
-    <GridCell span={3} spanMD={2} rowSpanMD={3} spanLG={3}>
+    <GridCell span={6} spanMD={2} rowSpanMD={3} spanLG={3}>
       <p className="cmp-type-body-default util-margin-top-none">As reported by respondents who create or maintain design systems, the top five challenges facing design systems are:</p>
     </GridCell>
-    <GridCell span={3} startMD={4} startMD={3} startLG={5}>
+    <GridCell span={6} spanSM={3} startMD={4} startMD={3} startLG={5}>
       <Number title="Overcoming technical / creative&nbsp;debt" number={1} />
     </GridCell>
-    <GridCell span={3} startSM={4} startMD={6} startLG={9}>
+    <GridCell span={6} spanSM={3} startSM={4} startMD={6} startLG={9}>
       <Number title="Parity between design and code" number={2} />
     </GridCell>
-    <GridCell span={3} startMD={3} startLG={5}>
+    <GridCell span={6} spanSM={3} startMD={3} startLG={5}>
       <Number title="Adoption" number={3} />
     </GridCell>
-    <GridCell span={3} startSM={4} startMD={6} startLG={9}>
+    <GridCell span={6} spanSM={3} startSM={4} startMD={6} startLG={9}>
       <Number title="Staffing" number={4} />
     </GridCell>
-    <GridCell span={3} startMD={3} startLG={5}>
+    <GridCell span={6} spanSM={3} startMD={3} startLG={5}>
       <Number title="Expanding the design system" number={5} />
     </GridCell>
   </Grid>

--- a/src/sections/2022/section-5.mdx
+++ b/src/sections/2022/section-5.mdx
@@ -17,17 +17,17 @@ import Quote from "../../components/2022/quote"
   
   <Quote source="Design System Maintainer">Good contributions are <span aria-label="so">SO</span> important. They are the crucial feedback required to tell you what's working and what's not.</Quote>
   
-  <Grid gap="lg" gapColMD="1xl" gapColLG="none">
+  <Grid gap="lg" gapColMD="1xl" gapColLG="2xl">
     <GridCell spanLG={9}>
       <p className="cmp-type-heading-3">Maintainers who viewed their design system as successful were very likely to have a contribution process for their design system.</p>
     </GridCell>
-    <GridCell span={3}>
+    <GridCell span={4} start={2} spanSM={3} startSM={1} spanMD={3} startMD={2} spanLG={4} startLG={1}>
       <Gauge title="Subscribers submitting coded features, updates, and/or bug fixes" number={92} size="large" />
     </GridCell>
-    <GridCell span={3} startLG={5}>
+    <GridCell span={4} start={2} spanSM={3} startSM={4} spanMD={3} startMD={5} spanLG={4} startLG={5}>
       <Gauge title="Subscribers submitting designs" number={83} size="large" />
     </GridCell>
-    <GridCell span={3} startLG={9}>
+    <GridCell span={4} start={2} spanSM={3} startSM={1} spanMD={3} startMD={2}  spanLG={4} startLG={9}>
       <Gauge title="Subscribers submitting feature requests and/or bug reports" number={76} size="large" />
     </GridCell>
   </Grid>

--- a/src/sections/2022/table-of-contents.mdx
+++ b/src/sections/2022/table-of-contents.mdx
@@ -6,23 +6,23 @@ import ScreenBlock from "../../components/2022/screen-block"
 <nav id="toc">
   <ScreenBlock>
     <h2 class="cmp-type-body-large util-pad-top-lg util-color-gray">Concepts</h2>
-    <Grid gap="md" gapMD="lg" gapLG="1xl" className="util-margin-vrt-10vh">
-      <GridCell spanLG="4" >
+    <Grid gap="lg" gapRowMD="1xl" className="util-margin-vrt-10vh">
+      <GridCell spanLG={4}>
         <TOCLink to={1} text="The Respondents" />
       </ GridCell>
-      <GridCell spanLG="4" startLG="6">
+      <GridCell spanLG={4} startMD={5} startLG={6}>
         <TOCLink to={2} text="What’s in a Design&nbsp;System" />
       </ GridCell>
-      <GridCell spanLG="4">
+      <GridCell spanLG={4}>
         <TOCLink to={3} text="Subscribers’ Needs" />
       </ GridCell>
-      <GridCell spanLG="4" startLG="6">
+      <GridCell spanLG={4} startMD={5} startLG={6}>
         <TOCLink to={4} text="Maintainers’ Challenges" />
       </ GridCell>
-      <GridCell spanLG="4">
+      <GridCell spanLG={4}>
         <TOCLink to={5} text="Accepting Contributions" />
       </ GridCell>
-      <GridCell spanLG="4" startLG="6">
+      <GridCell spanLG={4} startMD={5} startLG={6}>
         <TOCLink to={6} text="Looking Ahead" />
       </GridCell>
     </Grid>

--- a/src/sections/2022/table-of-contents.mdx
+++ b/src/sections/2022/table-of-contents.mdx
@@ -7,22 +7,22 @@ import ScreenBlock from "../../components/2022/screen-block"
   <ScreenBlock>
     <h2 class="cmp-type-body-large util-pad-top-lg util-color-gray">Concepts</h2>
     <Grid gap="lg" gapRowMD="1xl" className="util-margin-vrt-10vh">
-      <GridCell spanLG={4}>
+      <GridCell spanMD={4}>
         <TOCLink to={1} text="The Respondents" />
       </ GridCell>
-      <GridCell spanLG={4} startMD={5} startLG={6}>
+      <GridCell spanMD={4} startMD={5} startLG={7}>
         <TOCLink to={2} text="What’s in a Design&nbsp;System" />
       </ GridCell>
-      <GridCell spanLG={4}>
+      <GridCell spanMD={4} >
         <TOCLink to={3} text="Subscribers’ Needs" />
       </ GridCell>
-      <GridCell spanLG={4} startMD={5} startLG={6}>
+      <GridCell spanMD={4} startMD={5} startLG={7}>
         <TOCLink to={4} text="Maintainers’ Challenges" />
       </ GridCell>
-      <GridCell spanLG={4}>
+      <GridCell spanMD={4}>
         <TOCLink to={5} text="Accepting Contributions" />
       </ GridCell>
-      <GridCell spanLG={4} startMD={5} startLG={6}>
+      <GridCell spanMD={4} startMD={5} startLG={7}>
         <TOCLink to={6} text="Looking Ahead" />
       </GridCell>
     </Grid>


### PR DESCRIPTION
Addresses many responsive layout and sizing issues from smallest (appx 320px or 20rem) on up to the largest breakpoint (80rem). The primary concer is that content is legible. Please review by resizing the browser with the inspector open in order to get the width down to 320ish pixels, the slowly expand the browser width up, around 400pixels or more you can close the inspector and continue from that size up to at least 1280 or above.

**PLEASE Do Not Use Responsive Mode!**
Responsive mode is neat feature of browsers to mimic different devices sizes but there are two fundamental problems that make the bad for testing:
1. Responsive mode does not show the in between screen sizes that make RWD so beneficial.
2. They often require applying an artificial zoom to the page to fit the emulated device, distorting the page and hiding issues.

If you wish to test this on device, please use [BrowserStack](https://www.browserstack.com/) as an alternative if you do not have any devices on which to test.