### PR TITLE
[8] 2022/bar-chart

### DIFF
--- a/src/components/2022/bar-chart-table.js
+++ b/src/components/2022/bar-chart-table.js
@@ -1,0 +1,30 @@
+import React from "react"
+
+const BarChartTable = (props) => {
+  let tableRows = []
+
+  // Defines the contents of `<tbody>`
+  for (let i = 0; i < props.dataPoints.length; i++) {
+    tableRows.push(
+      <tr key={i}>
+        <th>
+          {props.dataPoints[i][0]}
+        </th>
+        <td>
+          {`${props.dataPoints[i][1]}%`}
+        </td>
+      </tr>
+    )
+  }
+
+  return (
+    <table className="util-visually-hidden">
+      <caption>{props.title}</caption>
+      <tbody>
+        {tableRows}
+      </tbody>
+    </table>
+  )
+}
+
+export default BarChartTable

--- a/src/components/2022/bar-chart.js
+++ b/src/components/2022/bar-chart.js
@@ -1,0 +1,48 @@
+import React from "react"
+import PropTypes from "prop-types"
+import BarChartTable from "./bar-chart-table"
+import Grid from "../../components/2022/grid"
+import GridCell from "../../components/2022/grid-cell"
+
+const BarChart = (props) => {
+  let dataBars = []
+
+  for (let i = 0; i < props.dataPoints.length; i++) {
+    let title = props.dataPoints[i][0]
+    let value = props.dataPoints[i][1]
+    let cssProperties = {}
+    cssProperties['--width'] = `${value}%`
+
+    dataBars.push(
+      <div className="cmp-bar-chart" key={i} style={cssProperties}>
+        <div className="cmp-bar-chart__title">
+          {title}
+        </div>
+        <div className="cmp-bar-chart__value">
+          {value}%
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div aria-hidden="true">
+        <Grid>
+          <GridCell spanMD={7} spanLG={9}>
+            <h3>{props.title}</h3>
+          </GridCell>
+        </Grid>
+        {dataBars}
+      </div>
+      <BarChartTable { ...props } />
+    </>
+  )
+}
+
+BarChart.propTypes = {
+  title: PropTypes.node.isRequired,
+  dataPoints: PropTypes.array.isRequired,
+}
+
+export default BarChart

--- a/src/scss/2022/base.scss
+++ b/src/scss/2022/base.scss
@@ -80,6 +80,7 @@
 @use "components/related-reading";
 @use "components/key-finding";
 @use "components/quote";
+@use "components/bar-chart";
 
 
 // =====================================================================

--- a/src/scss/2022/components/_bar-chart.scss
+++ b/src/scss/2022/components/_bar-chart.scss
@@ -1,0 +1,31 @@
+@use "../tools/typography";
+@use "../tools/svg" as *;
+
+.cmp-bar-chart {
+  & + & {
+    margin-top: var(--space-lg);
+  }
+
+  &__title {
+    @include typography.style("body-default");
+    margin-bottom: var(--space-sm);
+  }
+
+  &__value {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    @include typography.number("small");
+    line-height: 1;
+
+    &::before {
+      content: '';
+      display: block;
+      height: 1em;
+      width: var(--width);
+      margin-right: var(--space-md);
+      $width: 6;
+      background: svg('<svg height="#{$width}" width="#{$width}" viewBox="0 0 #{$width} #{$width}"><path d="M1,0 1,#{$width}" fill="none" stroke-width="0.5" stroke="white" /></svg>');
+    }
+  }
+}

--- a/src/sections/2022/section-2.mdx
+++ b/src/sections/2022/section-2.mdx
@@ -7,6 +7,7 @@ import Gauge from "../../components/2022/gauge"
 import RelatedReading from "../../components/2022/related-reading"
 import KeyFinding from "../../components/2022/key-finding"
 import Quote from "../../components/2022/quote"
+import BarChart from "../../components/2022/bar-chart"
 
 <ScreenBlock>
 <div id="section-2">
@@ -81,6 +82,22 @@ import Quote from "../../components/2022/quote"
   
   <div>CHART HERE</div>
   
+  <BarChart
+    headingLevel="h3"
+    title="Which of the following are established for the design system you use?"
+    dataPoints={[
+      ["Process for contributing", 61],
+      ["Process for determining which features or functionality will be added, updated, or removed", 44],
+      ["Roadmap of upcoming features", 44],
+      ["Support and training for current subscribers/contributors", 37],
+      ["New subscriber/contributor onboarding", 30],
+      ["Metrics tracking/reporting (usage, satisfaction, etc.)", 16],
+      ["I don't know/prefer not to say", 11],
+      ["Other", 4]
+    ]}
+   />
+  <p class="cmp-type-caption util-margin-top-lg">Respondents: 134 | Respondents were asked to select all that applied.</p>
+
   <Quote source="Design System Maintainer">[Our design system] has completely revolutionized how we collaborate with other teams and document and present our brand. Now, we can't imagine operating any other way.</Quote>
 
   <Grid gap="lg" gapColMD="1xl" gapColLG="none">

--- a/src/sections/2022/section-5.mdx
+++ b/src/sections/2022/section-5.mdx
@@ -6,6 +6,7 @@ import RelatedReading from "../../components/2022/related-reading"
 import Gauge from "../../components/2022/gauge"
 import KeyFinding from "../../components/2022/key-finding"
 import Quote from "../../components/2022/quote"
+import BarChart from "../../components/2022/bar-chart"
 
 <ScreenBlock>
 <div id="section-5">
@@ -13,8 +14,19 @@ import Quote from "../../components/2022/quote"
     <p>The most frequent approach to contribution reported by our maintainer respondents (at 57%) is to have subscribers submit feature requests and bug reports. But 36% of respondents said their design system lacks a defined process for accepting contributions and 4% said they don’t accept contributions at all.</p>
   </SectionHeader>
   
-  <p>BAR CHART</p>
-  
+  <BarChart
+    headingLevel="h3"
+    title="How do you accept contributions to the design system?"
+    dataPoints={[
+      ["Subscribers submit feature requests and/or bug reports", 57],
+      ["Subscribers submit designs", 37],
+      ["Subscribers submit coded features, updates, and/or bug fixes", 33],
+      ["We don't have a defined process for accepting contributions", 36],
+      ["We don't accept subscriber contributions", 4],
+      ["Other", 2]
+    ]} />
+  <p class="cmp-type-caption util-margin-top-lg">Responses: 162 | Respondents were asked to select all that applied.</p>
+
   <Quote source="Design System Maintainer">Good contributions are <span aria-label="so">SO</span> important. They are the crucial feedback required to tell you what's working and what's not.</Quote>
   
   <Grid gap="lg" gapColMD="1xl" gapColLG="2xl">


### PR DESCRIPTION
 Creates the Bart Chart styles and adds them to the appropriate sections.

<img width="1231" alt="CleanShot 2022-06-13 at 15 33 22@2x" src="https://user-images.githubusercontent.com/1128391/173430736-e923158a-55d1-4d03-912a-44ecc4658d0d.png">

## What needs checked:
- [ ] Install and run the project using the README instructions
- [ ] Sass code looks good
- [ ] React code looks good
- [ ] Small screen / responsiveness of chart

