### PR TITLE
[12] 2022/footer

### DIFF
--- a/src/components/2022/footer.js
+++ b/src/components/2022/footer.js
@@ -1,0 +1,68 @@
+import React from "react"
+
+const TwitterIcon = () => (
+  <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path d="M32 7.075a12.941 12.941 0 01-3.769 1.031 6.601 6.601 0 002.887-3.631 13.21 13.21 0 01-4.169 1.594A6.565 6.565 0 0022.155 4a6.563 6.563 0 00-6.563 6.563c0 .512.056 1.012.169 1.494A18.635 18.635 0 012.23 5.195a6.56 6.56 0 00-.887 3.3 6.557 6.557 0 002.919 5.463 6.565 6.565 0 01-2.975-.819v.081a6.565 6.565 0 005.269 6.437 6.574 6.574 0 01-2.968.112 6.588 6.588 0 006.131 4.563 13.17 13.17 0 01-9.725 2.719 18.568 18.568 0 0010.069 2.95c12.075 0 18.681-10.006 18.681-18.681 0-.287-.006-.569-.019-.85A13.216 13.216 0 0032 7.076z" fill="currentColor" /></svg>
+)
+
+const GithubIcon = () => (
+  <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path d="M16 .395c-8.836 0-16 7.163-16 16 0 7.069 4.585 13.067 10.942 15.182.8.148 1.094-.347 1.094-.77 0-.381-.015-1.642-.022-2.979-4.452.968-5.391-1.888-5.391-1.888-.728-1.849-1.776-2.341-1.776-2.341-1.452-.993.11-.973.11-.973 1.606.113 2.452 1.649 2.452 1.649 1.427 2.446 3.743 1.739 4.656 1.33.143-1.034.558-1.74 1.016-2.14-3.554-.404-7.29-1.777-7.29-7.907 0-1.747.625-3.174 1.649-4.295-.166-.403-.714-2.03.155-4.234 0 0 1.344-.43 4.401 1.64a15.353 15.353 0 014.005-.539c1.359.006 2.729.184 4.008.539 3.054-2.07 4.395-1.64 4.395-1.64.871 2.204.323 3.831.157 4.234 1.026 1.12 1.647 2.548 1.647 4.295 0 6.145-3.743 7.498-7.306 7.895.574.497 1.085 1.47 1.085 2.963 0 2.141-.019 3.864-.019 4.391 0 .426.288.925 1.099.768C27.421 29.457 32 23.462 32 16.395c0-8.837-7.164-16-16-16z" fill="currentColor" /></svg>
+)
+
+const DribbbleIcon = () => (
+  <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path d="M16 32C7.175 32 0 24.825 0 16S7.175 0 16 0s16 7.175 16 16-7.175 16-16 16zm13.494-13.812c-.469-.15-4.231-1.269-8.512-.581 1.788 4.912 2.512 8.912 2.656 9.744 3.063-2.075 5.25-5.356 5.856-9.163zM21.337 28.6c-.206-1.2-.994-5.375-2.913-10.363-.031.012-.063.019-.087.031-7.713 2.688-10.481 8.031-10.725 8.531a13.612 13.612 0 008.387 2.887c1.894 0 3.7-.387 5.338-1.087zM5.844 25.156c.313-.531 4.063-6.738 11.106-9.019.175-.056.356-.113.538-.162a50.041 50.041 0 00-1.106-2.319C9.563 15.7 2.938 15.612 2.338 15.606c-.006.137-.006.275-.006.419 0 3.506 1.331 6.712 3.512 9.131zM2.625 13.219c.612.006 6.244.031 12.637-1.662a86.017 86.017 0 00-5.069-7.906C6.368 5.457 3.505 8.982 2.624 13.22zM12.8 2.731a73.225 73.225 0 015.1 8c4.863-1.819 6.919-4.588 7.163-4.938A13.598 13.598 0 0016 2.349a14.22 14.22 0 00-3.2.381zm13.781 4.65c-.288.388-2.581 3.325-7.631 5.388.319.65.625 1.313.906 1.981.1.238.2.469.294.706 4.55-.569 9.069.344 9.519.438a13.628 13.628 0 00-3.087-8.512z" fill="currentColor" /></svg>
+)
+
+const FacebookIcon = () => (
+  <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path d="M19 6h5V0h-5c-3.86 0-7 3.14-7 7v3H8v6h4v16h6V16h5l1-6h-6V7c0-.542.458-1 1-1z" fill="currentColor"/></svg>
+)
+
+const YoutubeIcon = () => (
+  <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path d="M31.681 9.6s-.313-2.206-1.275-3.175C29.187 5.15 27.825 5.144 27.2 5.069c-4.475-.325-11.194-.325-11.194-.325h-.012s-6.719 0-11.194.325c-.625.075-1.987.081-3.206 1.356C.631 7.394.325 9.6.325 9.6s-.319 2.588-.319 5.181v2.425c0 2.587.319 5.181.319 5.181s.313 2.206 1.269 3.175c1.219 1.275 2.819 1.231 3.531 1.369 2.563.244 10.881.319 10.881.319s6.725-.012 11.2-.331c.625-.075 1.988-.081 3.206-1.356.962-.969 1.275-3.175 1.275-3.175s.319-2.587.319-5.181v-2.425c-.006-2.588-.325-5.181-.325-5.181zM12.694 20.15v-8.994l8.644 4.513-8.644 4.481z" fill="currentColor" /></svg>
+)
+
+const LinkedinIcon = () => (
+  <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path d="M12 12h5.535v2.837h.079c.77-1.381 2.655-2.837 5.464-2.837C28.92 12 30 15.637 30 20.367V30h-5.769v-8.54c0-2.037-.042-4.657-3.001-4.657-3.005 0-3.463 2.218-3.463 4.509V30H12V12zM2 12h6v18H2V12zM8 7a3 3 0 11-6 0 3 3 0 016 0z" fill="currentColor" /></svg>
+)
+
+
+const Footer = () => (
+  <footer className="cmp-footer util-pad-vrt-lg">
+    <p className="cmp-type-body-large">Assembled by your friends at <a href="https://sparkbox.com/">Sparkbox</a></p>  
+    <nav className="cmp-footer__social" title="Sparkbox social media (external)">
+      <a href="https://twitter.com/hearsparkbox" className="cmp-footer__social-link cmp-footer__social-link--twitter">
+        <span className="util-visually-hidden">Twitter</span>
+        <TwitterIcon />
+      </a>
+      <a href="https://github.com/sparkbox" className="cmp-footer__social-link cmp-footer__social-link--github">
+        <span className="util-visually-hidden">Github</span>
+        <GithubIcon />
+      </a>
+      <a href="https://dribbble.com/sparkbox" className="cmp-footer__social-link cmp-footer__social-link--dribbble">
+        <span className="util-visually-hidden">Dribbble</span>
+        <DribbbleIcon />
+      </a>
+      <a href="https://www.facebook.com/seesparkbox" className="cmp-footer__social-link cmp-footer__social-link--facebook">
+        <span className="util-visually-hidden">Facebook</span>
+        <FacebookIcon />
+      </a>
+      <a href="https://www.youtube.com/channel/UCfsWcRy7Yh1WWDrrZS0Q7xw" className="cmp-footer__social-link cmp-footer__social-link--youtube">
+        <span className="util-visually-hidden">Youtube</span>
+        <YoutubeIcon />
+      </a>
+      <a href="https://www.linkedin.com/company/sparkbox/mycompany/" className="cmp-footer__social-link cmp-footer__social-link--linkedin">
+        <span className="util-visually-hidden">LinkedIn</span>
+        <LinkedinIcon />
+      </a>
+    </nav>
+
+    <nav className="cmp-footer__links-list">
+      <a href="https://sparkbox.com/contact">Drop us a line</a>
+      <a href="https://sparkbox.com/contact#careers">Careers</a>
+      <a href="https://apprentices.seesparkbox.com">Apprenticeship</a>
+    </nav>
+
+    <p className="cmp-footer__copyright">&copy;2022 Sparkbox. All rights reserved. <a href="https://sparkbox.com/privacypolicy">Privacy Policy</a> and <a href="https://sparkbox.com/terms">Terms of Use</a></p>
+  </footer>
+)
+
+export default Footer

--- a/src/pages/2022.js
+++ b/src/pages/2022.js
@@ -54,6 +54,7 @@ class Page2022 extends Component {
           <Section5 />
           <Section6 />
           <ContactFormNewsletter />
+          <Footer />
         </Layout>
       </>
     )

--- a/src/scss/2022/base.scss
+++ b/src/scss/2022/base.scss
@@ -87,6 +87,7 @@
 @use "components/comparison-chart";
 @use "components/comparison-key";
 @use "components/form";
+@use "components/footer";
 
 
 // =====================================================================

--- a/src/scss/2022/components/_footer.scss
+++ b/src/scss/2022/components/_footer.scss
@@ -1,0 +1,45 @@
+@use "../tools/typography";
+
+.cmp-footer {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  width: 100%;
+  gap: var(--space-md);
+  
+  &__social {
+    display: flex;
+    justify-content: center;
+    gap: var(--space-md);
+    margin-top: var(--space-md);
+  }
+  
+  &__social-link {
+    border-radius: 2px;
+    display: block; 
+    padding: 0.25rem;
+    line-height: 0.75;
+    color: var(--color-black);
+    background-color: var(--color-white);
+    box-shadow: 0 0 0 0 var(--color-black), 0 0 0 0 var(--color-dark);
+    transition: box-shadow 150ms ease-in-out;
+    
+    &:hover {
+      box-shadow: 0 0 0 2px var(--color-black), 0 0 0 6px var(--color-dark);
+    }
+  }
+  
+  &__links-list {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin: var(--space-lg) 0;
+    gap: var(--space-md) var(--space-lg);
+    @include typography.style('body-large');
+  }
+  
+  &__copyright {
+    @include typography.style('body-default');
+  }
+}


### PR DESCRIPTION
This is fairly simple. The footer from 2021 was brought in to 2022 and styles were matched. It should look similar to this image from Figma, but with social media icons in the boxes:

<img width="1220" alt="CleanShot 2022-06-13 at 15 43 29@2x" src="https://user-images.githubusercontent.com/1128391/173432485-22d851b6-7461-44e1-91b0-24fb8f65491f.png">
