### PR TITLE
feat: Add Google Tag Manager

### DIFF
--- a/2018/src/drizzle/templates/template.hbs
+++ b/2018/src/drizzle/templates/template.hbs
@@ -1,13 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <!-- Google Tag Manager -->
-      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','GTM-WHPGCMR');</script>
-    <!-- End Google Tag Manager -->
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
@@ -30,15 +23,25 @@
     {{!--  Font: IBM Plex Serif via Google Fonts --}}
     <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Serif:400,400i,700,700i" rel="stylesheet">
     <link rel="stylesheet" href="/2018/css/base.css">
-    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-611206884"></script>
-    <script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'AW-611206884'); </script>
+    <!-- Google Tag Manager -->
+    <script>
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || []; w[l].push({
+          'gtm.start':
+            new Date().getTime(), event: 'gtm.js'
+        }); var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
+            'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', 'GTM-KQ53HCR');
+    </script>
+    <!-- End Google Tag Manager -->
   </head>
+
   <body>
     <!-- Google Tag Manager (noscript) -->
-      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WHPGCMR"
-      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KQ53HCR" height="0" width="0"
+        style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
-
     <a href="/" class="cmp-latest-link">Check out the results from the latest <span class="cmp-latest-link__styled">Design Systems Survey</span></a>
 
     {{#block "body"}}

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -34,9 +34,15 @@ module.exports = {
     },
     `gatsby-plugin-mdx`,
     {
-      resolve: `gatsby-plugin-google-gtag`,
+      resolve: 'gatsby-plugin-google-gtag',
       options: {
-        trackingIds: ['GTM-WHPGCMR', 'AW-611206884'],
+        trackingIds: ['GTM-KQ53HCR'],
+        gtagConfig: {
+          anonymize_ip: true,
+        },
+        pluginConfig: {
+          head: true,
+        },
       },
     },
     {

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -16,7 +16,7 @@ class SEO extends Component {
   }
 
   componentDidMount() {
-    this.setState({ 
+    this.setState({
       htmlClass : this.htmlClassCheck(),
     })
   }
@@ -49,6 +49,20 @@ class SEO extends Component {
           `}
         render = { data => (
           <Helmet title={`The ${this.props.year} ${data.site.siteMetadata.titleTemplate}`}>
+            <script
+              async
+              src="https://www.googletagmanager.com/gtag/js?id=GTM-KQ53HCR"
+            ></script>
+            <script
+              dangerouslySetInnerHTML={{
+                __html: `
+                  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
+                  var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
+                  j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
+                  f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KQ53HCR');
+                `,
+              }}
+            />
             <html className={this.state.htmlClass} lang="en"/>
             <meta name="application-name" content={`${this.props.year} Design Systems Survey`} />
             <meta name="author" content={data.site.siteMetadata.author} />

--- a/src/pages/2019.js
+++ b/src/pages/2019.js
@@ -22,6 +22,11 @@ const Page2019 = () => (
       fontCSS="https://cloud.typography.com/655912/7241412/css/fonts.css"
       year="2019"
     />
+    {/* <!-- Google Tag Manager (noscript) --> */}
+    <noscript dangerouslySetInnerHTML={{
+      __html: `<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KQ53HCR" height="0" width="0" style="display:none;visibility:hidden"></iframe>`,
+    }} />
+    {/* <!-- End Google Tag Manager (noscript) --> */}
     <svg width="0" height="0" className="util-visually-hidden">
       <defs>
         <linearGradient id="pinkyellow" x1="50%" x2="50%" y1="0%" y2="100%">

--- a/src/pages/2020.js
+++ b/src/pages/2020.js
@@ -31,6 +31,13 @@ class Page2020 extends Component {
           <link rel="preload" as="font" href="https://assets.sparkbox.com/fonts/sole/sole-serif-headline-extrabold/font.woff2" type="font/woff2" crossorigin="anonymous" />
           <link rel="preload" as="font" href="https://assets.sparkbox.com/fonts/sole/sole-serif-text-light/font.woff2" type="font/woff2" crossorigin="anonymous" />
         </Helmet>
+        {/* <!-- Google Tag Manager (noscript) --> */}
+        <noscript dangerouslySetInnerHTML={{
+          __html: `<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KQ53HCR" height="0" width="0"
+              style="display:none;visibility:hidden"></iframe>
+            `,
+        }} />
+        {/* <!-- End Google Tag Manager (noscript) --> */}
         <IntroSection />
         <main>
           <TableOfContents />

--- a/src/pages/2021.js
+++ b/src/pages/2021.js
@@ -47,6 +47,14 @@ class Page2021 extends Component {
           <link rel="stylesheet" type="text/css" href="/css/2021-ie.css" media={ieCSS} />
         </Helmet>
 
+        {/* <!-- Google Tag Manager (noscript) --> */}
+        <noscript dangerouslySetInnerHTML={{
+          __html: `<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KQ53HCR" height="0" width="0"
+              style="display:none;visibility:hidden"></iframe>
+            `,
+        }} />
+        {/* <!-- End Google Tag Manager (noscript) --> */}
+
         <div className="obj-lines obj-max-width">
 
           <FixedSides />

--- a/src/pages/2022.js
+++ b/src/pages/2022.js
@@ -50,6 +50,13 @@ class Page2022 extends Component {
           />
         </Helmet>
         <Layout>
+          {/* <!-- Google Tag Manager (noscript) --> */}
+          <noscript dangerouslySetInnerHTML={{
+            __html: `<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KQ53HCR" height="0" width="0"
+              style="display:none;visibility:hidden"></iframe>
+            `,
+          }} />
+          {/* <!-- End Google Tag Manager (noscript) --> */}
           <a className="cmp-skip-link" href="#toc">Skip to Menu</a>
           <a className="cmp-skip-link" href="#section-1">Skip to Content</a>
 

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -27,6 +27,13 @@ class NotFoundPage extends Component {
           />
         </Helmet>
 
+        {/* <!-- Google Tag Manager (noscript) --> */}
+        <noscript dangerouslySetInnerHTML={{
+          __html: `<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KQ53HCR" height="0" width="0"
+              style="display:none;visibility:hidden"></iframe>
+            `,
+        }} />
+        {/* <!-- End Google Tag Manager (noscript) --> */}
         
         <Circle />
         <div className="cmp-hero">


### PR DESCRIPTION
## Description
Adds our new google tag manager that we're using on all of the sites we own. [SC-1719](https://sparkbox.atlassian.net/browse/SC-1719)

## To Validate

1. You don't have to run the project locally, you can just open [the Netlify deploy](https://deploy-preview-365--angry-mirzakhani-365cef.netlify.app/) for this PR
2. Check each of the following pages to find scripts with our GTM id in the `<head>` (see below) and a noscript with our GTM id in the `<body>` (also below)
    1. /2022
    2. /2021
    3. /2020
    4. /2019
    5. /2018

### `<head>` scripts:

`<script async="true" src="https://www.googletagmanager.com/gtag/js?id=GTM-KQ53HCR" data-react-helmet="true"></script>`

```
<script>
      function gaOptout(){document.cookie=disableStr+'=true; expires=Thu, 31 Dec 2099 23:59:59 UTC;path=/',window[disableStr]=!0}var gaProperty='GTM-KQ53HCR',disableStr='ga-disable-'+gaProperty;document.cookie.indexOf(disableStr+'=true')>-1&&(window[disableStr]=!0);
      if(true) {
        window.dataLayer = window.dataLayer || [];
        function gtag(){window.dataLayer && window.dataLayer.push(arguments);}
        gtag('js', new Date());

        gtag('config', 'GTM-KQ53HCR', {"anonymize_ip":true,"send_page_view":false});
      }
</script>
```

### `<body>` noscript:

`<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KQ53HCR" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>`

[SC-1719]: https://sparkbox.atlassian.net/browse/SC-1719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ